### PR TITLE
Info insert

### DIFF
--- a/src/lib/components/ArticleCard.svelte
+++ b/src/lib/components/ArticleCard.svelte
@@ -5,6 +5,7 @@
 	export let blurb
 	export let category = ''
 	export let url
+	export let linkText = "Lire l'article"
 </script>
 
 <a class="article-link" href={url}>
@@ -14,7 +15,7 @@
 		<div class="footer small-text">
 			<span>{category}</span>
 			<span class="read-more">
-				Lire l'article<span class="link-icon"><MoveUpRight size="1.5rem" /></span>
+				{linkText}<span class="link-icon"><MoveUpRight size="1.5rem" /></span>
 			</span>
 		</div>
 	</article>

--- a/src/lib/components/home/inserts.svelte
+++ b/src/lib/components/home/inserts.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import ArticleCard from '$components/ArticleCard.svelte'
+	import UnderlinedTitle from '$components/UnderlinedTitle.svelte'
+	const label_id = 'inserts-title'
+</script>
+
+<section aria-labelledby={label_id}>
+	<UnderlinedTitle id={label_id}>Rapports et Solutions</UnderlinedTitle>
+	<div class="inserts-grid">
+		<ArticleCard
+			title="IA{' '}: nos craintes pour la France"
+			blurb="Analyse critique du rapport de la Commission IA, soulignant les risques ignorés et les conflits d'intérêts."
+			url="https://contre-rapport-ia.fr/"
+			linkText="Voir le site"
+		/>
+		<ArticleCard
+			title="Reprendre le Contrôle: Forum des solutions pour une IA compatible avec l'humanité"
+			blurb="Explorer les approches et solutions pour une gestion responsable de l'IA."
+			url="https://controleia.org/solutions/"
+			linkText="Voir le site"
+		/>
+	</div>
+</section>
+
+<style>
+	.inserts-grid {
+		display: grid;
+		gap: 1rem;
+		margin-bottom: 2rem; /* Match spacing if needed */
+	}
+
+	@media (min-width: 640px) {
+		.inserts-grid {
+			grid-template-columns: 1fr 1fr;
+		}
+	}
+
+	/* Optional: Adjust grid for larger screens if desired, like articles */
+	/* @media (min-width: 1024px) {
+		.inserts-grid {
+			grid-template-columns: 1fr 1fr 1fr; // If you want 3 columns on large screens
+		}
+	} */
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -21,12 +21,12 @@
 
 <Risks />
 
-<Supporters />
-
-<Articles />
-
 <Videos />
 
 <Inserts />
+
+<Articles />
+
+<Supporters />
 
 <Faq />

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -7,6 +7,7 @@
 	import Faq from '$components/home/faq.svelte'
 	import Videos from '$components/home/videos.svelte'
 	import Supporters from '$components/home/supporters.svelte'
+	import Inserts from '$components/home/inserts.svelte'
 
 	const title = 'Exigeons une Pause IA'
 	const description = "Ne laissons pas l'IA nous détruire, agissons maintenant"
@@ -25,5 +26,7 @@
 <Articles />
 
 <Videos />
+
+<Inserts />
 
 <Faq />


### PR DESCRIPTION
feat: Add Inserts section and customizable card link text

Adds a new 'Inserts' section to the homepage with links to external reports.
Makes the link text in ArticleCard configurable via a prop, defaulting to "Lire l'article", and sets it to "Voir le site" for the new Inserts cards.
Reorders sections on the main page.