### PR TITLE
feat(campagnes): popup bilan pour les campagnes terminées

### DIFF
--- a/src/lib/campaigns.ts
+++ b/src/lib/campaigns.ts
@@ -1,5 +1,21 @@
 export type CampaignStatus = 'active' | 'ended'
 
+export interface CampaignResult {
+	label: string
+	value: string
+}
+
+export interface CampaignSummary {
+	fr: {
+		text: string
+		results: CampaignResult[]
+	}
+	en: {
+		text: string
+		results: CampaignResult[]
+	}
+}
+
 export interface Campaign {
 	/** URL slug, e.g. 'municipales-2026' → /fr/municipales-2026 */
 	slug: string
@@ -10,6 +26,8 @@ export interface Campaign {
 	endDate?: string
 	/** Override URL (absolute path). If omitted, defaults to /{lang}/{slug} */
 	url?: string
+	/** Summary shown in a popup when the ended campaign card is clicked */
+	summary?: CampaignSummary
 	fr: {
 		title: string
 		description: string
@@ -34,6 +52,22 @@ export const campaigns: Campaign[] = [
 		status: 'ended',
 		startDate: '2026-01',
 		endDate: '2026-02',
+		summary: {
+			fr: {
+				text: "Pause IA a mené une campagne de mobilisation autour du Sommet de l'IA 2026 en Inde, en appelant les citoyens à signer la pétition internationale et à interpeller les décideurs politiques pour placer la sécurité au centre des discussions.",
+				results: [
+					{ label: 'Pétition', value: 'Relais de la pétition internationale' },
+					{ label: 'Interpellations', value: 'Décideurs politiques contactés' }
+				]
+			},
+			en: {
+				text: 'Pause AI France ran a mobilization campaign around the 2026 AI Summit in India, calling on citizens to sign the international petition and contact decision-makers to put safety at the heart of the discussions.',
+				results: [
+					{ label: 'Petition', value: 'International petition relay' },
+					{ label: 'Outreach', value: 'Decision-makers contacted' }
+				]
+			}
+		},
 		fr: {
 			title: "Sommet de l'IA 2026",
 			description:
@@ -52,6 +86,26 @@ export const campaigns: Campaign[] = [
 		status: 'ended',
 		startDate: '2026-03',
 		endDate: '2026-03',
+		summary: {
+			fr: {
+				text: "Pause IA a interpellé les candidats aux élections municipales de mars 2026 pour les inviter à signer une charte en 14 engagements sur les risques liés à l'IA. La campagne a mobilisé dans toute la France et généré une couverture médiatique nationale.",
+				results: [
+					{ label: 'Signataires', value: '12 candidats' },
+					{ label: 'Villes', value: '11 villes' },
+					{ label: 'Chartes complètes', value: '7 signataires (14/14)' },
+					{ label: 'Presse', value: '10 articles (dont France Culture)' }
+				]
+			},
+			en: {
+				text: 'Pause AI challenged candidates in the March 2026 municipal elections to sign a charter with 14 commitments on AI risks. The campaign mobilized across France and received national media coverage.',
+				results: [
+					{ label: 'Signatories', value: '12 candidates' },
+					{ label: 'Cities', value: '11 cities' },
+					{ label: 'Full charters', value: '7 signatories (14/14)' },
+					{ label: 'Press', value: '10 articles (incl. France Culture)' }
+				]
+			}
+		},
 		fr: {
 			title: 'Élections municipales 2026',
 			description:

--- a/src/lib/campaigns.ts
+++ b/src/lib/campaigns.ts
@@ -106,8 +106,7 @@ export const campaigns: Campaign[] = [
 					{ label: 'Villes', value: '11 villes' },
 					{ label: 'Chartes complètes', value: '7 signataires (14/14)' },
 					{ label: 'Presse', value: '10 articles + 1 émission (France Culture)' }
-				],
-				link: { label: 'Voir la couverture presse', url: '/fr/presse' }
+				]
 			},
 			en: {
 				text: 'Pause AI challenged candidates in the March 2026 municipal elections to sign a charter with 14 commitments on AI risks. The campaign mobilized across France and received national media coverage.',
@@ -116,8 +115,7 @@ export const campaigns: Campaign[] = [
 					{ label: 'Cities', value: '11 cities' },
 					{ label: 'Full charters', value: '7 signatories (14/14)' },
 					{ label: 'Press', value: '10 articles + 1 broadcast (France Culture)' }
-				],
-				link: { label: 'See press coverage', url: '/en/presse' }
+				]
 			}
 		},
 		fr: {

--- a/src/lib/campaigns.ts
+++ b/src/lib/campaigns.ts
@@ -105,8 +105,9 @@ export const campaigns: Campaign[] = [
 					{ label: 'Signataires', value: '12 candidats' },
 					{ label: 'Villes', value: '11 villes' },
 					{ label: 'Chartes complètes', value: '7 signataires (14/14)' },
-					{ label: 'Presse', value: '10 articles (dont France Culture)' }
-				]
+					{ label: 'Presse', value: '10 articles + 1 émission (France Culture)' }
+				],
+				link: { label: 'Voir la couverture presse', url: '/fr/presse' }
 			},
 			en: {
 				text: 'Pause AI challenged candidates in the March 2026 municipal elections to sign a charter with 14 commitments on AI risks. The campaign mobilized across France and received national media coverage.',
@@ -114,8 +115,9 @@ export const campaigns: Campaign[] = [
 					{ label: 'Signatories', value: '12 candidates' },
 					{ label: 'Cities', value: '11 cities' },
 					{ label: 'Full charters', value: '7 signatories (14/14)' },
-					{ label: 'Press', value: '10 articles (incl. France Culture)' }
-				]
+					{ label: 'Press', value: '10 articles + 1 broadcast (France Culture)' }
+				],
+				link: { label: 'See press coverage', url: '/en/presse' }
 			}
 		},
 		fr: {

--- a/src/lib/campaigns.ts
+++ b/src/lib/campaigns.ts
@@ -9,10 +9,12 @@ export interface CampaignSummary {
 	fr: {
 		text: string
 		results: CampaignResult[]
+		link?: { label: string; url: string }
 	}
 	en: {
 		text: string
 		results: CampaignResult[]
+		link?: { label: string; url: string }
 	}
 }
 
@@ -54,18 +56,30 @@ export const campaigns: Campaign[] = [
 		endDate: '2026-02',
 		summary: {
 			fr: {
-				text: "Pause IA a mené une campagne de mobilisation autour du Sommet de l'IA 2026 en Inde, en appelant les citoyens à signer la pétition internationale et à interpeller les décideurs politiques pour placer la sécurité au centre des discussions.",
+				text: "Pause IA a mobilisé pour que le Sommet de l'IA en Inde remette la sécurité au cœur de l'agenda international. Plus de 2 200 personnes ont signé la pétition et plus de 2 000 mails ont été envoyés aux délégués de 14 pays différents. Une tribune a été publiée dans Le Nouvel Obs, soutenue par des personnalités académiques, politiques et associatives.",
 				results: [
-					{ label: 'Pétition', value: 'Relais de la pétition internationale' },
-					{ label: 'Interpellations', value: 'Décideurs politiques contactés' }
-				]
+					{ label: 'Pétition', value: '2 200+ signatures' },
+					{ label: 'Mails aux délégués', value: '2 000+ (14 pays)' },
+					{ label: 'Tribune', value: 'Le Nouvel Obs — 16 fév. 2026' },
+					{ label: 'Signataires tribune', value: 'Personnalités académiques & politiques' }
+				],
+				link: {
+					label: 'Lire la tribune dans Le Nouvel Obs',
+					url: 'https://www.nouvelobs.com/opinions/20260216.OBS112421/sommet-de-l-ia-face-aux-risques-remettre-la-securite-en-haut-de-l-agenda-international.html'
+				}
 			},
 			en: {
-				text: 'Pause AI France ran a mobilization campaign around the 2026 AI Summit in India, calling on citizens to sign the international petition and contact decision-makers to put safety at the heart of the discussions.',
+				text: 'Pause AI France mobilized to put safety back at the heart of the international AI agenda at the India AI Summit. Over 2,200 people signed the petition and over 2,000 emails were sent to delegates from 14 different countries. An op-ed was published in Le Nouvel Obs, supported by academic, political and civic figures.',
 				results: [
-					{ label: 'Petition', value: 'International petition relay' },
-					{ label: 'Outreach', value: 'Decision-makers contacted' }
-				]
+					{ label: 'Petition', value: '2,200+ signatures' },
+					{ label: 'Emails to delegates', value: '2,000+ (14 countries)' },
+					{ label: 'Op-ed', value: 'Le Nouvel Obs — 16 Feb. 2026' },
+					{ label: 'Op-ed signatories', value: 'Academic & political figures' }
+				],
+				link: {
+					label: 'Read the op-ed in Le Nouvel Obs',
+					url: 'https://www.nouvelobs.com/opinions/20260216.OBS112421/sommet-de-l-ia-face-aux-risques-remettre-la-securite-en-haut-de-l-agenda-international.html'
+				}
 			}
 		},
 		fr: {

--- a/src/lib/campaigns.ts
+++ b/src/lib/campaigns.ts
@@ -5,16 +5,24 @@ export interface CampaignResult {
 	value: string
 }
 
+export interface CampaignArticle {
+	title: string
+	source: string
+	url: string
+}
+
 export interface CampaignSummary {
 	fr: {
 		text: string
 		results: CampaignResult[]
 		link?: { label: string; url: string }
+		articles?: CampaignArticle[]
 	}
 	en: {
 		text: string
 		results: CampaignResult[]
 		link?: { label: string; url: string }
+		articles?: CampaignArticle[]
 	}
 }
 
@@ -106,6 +114,60 @@ export const campaigns: Campaign[] = [
 					{ label: 'Villes', value: '11 villes' },
 					{ label: 'Chartes complètes', value: '7 signataires (14/14)' },
 					{ label: 'Presse', value: '10 articles + 1 émission (France Culture)' }
+				],
+				articles: [
+					{
+						title: "Quand l'IA s'invite dans les municipales",
+						source: 'Next',
+						url: 'https://next.ink/229085/quand-lia-sinvite-dans-les-municipales/'
+					},
+					{
+						title: 'Journal de 18h — vendredi 13 mars 2026',
+						source: 'France Culture',
+						url: 'https://www.radiofrance.fr/franceculture/podcasts/journal-de-18h/journal-de-18h-emission-du-vendredi-13-mars-2026-9405796'
+					},
+					{
+						title: '« Les candidats aux municipales doivent se positionner » (Avignon)',
+						source: 'Presse Agence',
+						url: 'https://presseagence.fr/avignon-clemence-peyrot-les-candidats-aux-municipales-doivent-se-positionner/'
+					},
+					{
+						title:
+							"Annecy : une association interpelle les candidats sur l'intelligence artificielle",
+						source: 'ODS Radio',
+						url: 'https://www.odsradio.com/news/locales/108150/annecy-une-association-interpelle-les-candidats-sur-l-intelligence-artificielle'
+					},
+					{
+						title: "Pause IA s'incruste dans les municipales",
+						source: 'Contexte',
+						url: 'https://www.contexte.com/fr/actualite/tech/pause-ia-sincruste-dans-les-municipales_257807'
+					},
+					{
+						title:
+							"Risques IA : l'association interpelle les candidats aux municipales de Toulouse",
+						source: "L'Opinion",
+						url: 'https://lopinion.com/amp/articles/actualite/32757_risques-ia-association-candidats-municipales-toulouse'
+					},
+					{
+						title: '« Les candidats aux municipales doivent se positionner clairement » (Nice)',
+						source: 'Presse Agence',
+						url: 'https://presseagence.fr/nice-maxime-fournes-les-candidats-aux-municipales-doivent-se-positionner-clairement/'
+					},
+					{
+						title: "Municipales 2026 : Pause IA interpelle les candidats sur les dangers de l'IA",
+						source: "Place Gre'net",
+						url: 'https://www.placegrenet.fr/2026/03/08/municipales-2026-pause-ia-interpelle-les-candidats-sur-les-dangers-de-lintelligence-artificielle/673506'
+					},
+					{
+						title: "Isère / Grenoble : Pause IA appelle les candidats à s'engager sur sa charte",
+						source: 'Le Dauphiné Libéré',
+						url: 'https://www.ledauphine.com/elections/2026/03/06/isere-grenoble-l-association-pause-ia-appelle-les-candidats-a-s-engager-sur-sa-charte'
+					},
+					{
+						title: "Nice : Jean-Marc Governatori s'engage sur la charte de Pause IA",
+						source: 'Presse Agence',
+						url: 'https://presseagence.fr/nice-jean-marc-governatori-sengage-sur-la-charte-de-pause-ia-pour-les-municipales/'
+					}
 				]
 			},
 			en: {

--- a/src/lib/campaigns.ts
+++ b/src/lib/campaigns.ts
@@ -56,7 +56,7 @@ export const campaigns: Campaign[] = [
 		endDate: '2026-02',
 		summary: {
 			fr: {
-				text: "Pause IA a mobilisé pour que le Sommet de l'IA en Inde remette la sécurité au cœur de l'agenda international. Plus de 4 000 personnes ont signé la pétition et plus de 2 000 mails ont été envoyés aux délégués dans 14 pays. Une tribune a également été publiée dans Le Nouvel Obs.",
+				text: "À l'occasion du Sommet de l'IA en Inde, Pause IA s'est mobilisée pour remettre la sécurité au cœur de l'agenda international. Plus de 4 000 personnes ont signé la pétition et plus de 2 000 mails ont été envoyés aux délégués dans 14 pays. Une tribune a également été publiée dans Le Nouvel Obs.",
 				results: [
 					{ label: 'Signatures pétition', value: '+4 000' },
 					{ label: 'Mails aux délégués', value: '+2 000 (14 pays)' },

--- a/src/lib/campaigns.ts
+++ b/src/lib/campaigns.ts
@@ -56,12 +56,11 @@ export const campaigns: Campaign[] = [
 		endDate: '2026-02',
 		summary: {
 			fr: {
-				text: "Pause IA a mobilisé pour que le Sommet de l'IA en Inde remette la sécurité au cœur de l'agenda international. Plus de 2 200 personnes ont signé la pétition et plus de 2 000 mails ont été envoyés aux délégués de 14 pays différents. Une tribune a été publiée dans Le Nouvel Obs, soutenue par des personnalités académiques, politiques et associatives.",
+				text: "Pause IA a mobilisé pour que le Sommet de l'IA en Inde remette la sécurité au cœur de l'agenda international. Plus de 4 000 personnes ont signé la pétition et plus de 2 000 mails ont été envoyés aux délégués dans 14 pays. Une tribune a également été publiée dans Le Nouvel Obs.",
 				results: [
-					{ label: 'Pétition', value: '4 057 signatures vérifiées' },
-					{ label: 'Mails aux délégués', value: '2 000+ (14 pays)' },
-					{ label: 'Tribune', value: 'Le Nouvel Obs — 16 fév. 2026' },
-					{ label: 'Signataires tribune', value: 'Personnalités académiques & politiques' }
+					{ label: 'Signatures pétition', value: '+4 000' },
+					{ label: 'Mails aux délégués', value: '+2 000 (14 pays)' },
+					{ label: 'Tribune', value: 'Le Nouvel Obs' }
 				],
 				link: {
 					label: 'Lire la tribune dans Le Nouvel Obs',
@@ -69,12 +68,11 @@ export const campaigns: Campaign[] = [
 				}
 			},
 			en: {
-				text: 'Pause AI France mobilized to put safety back at the heart of the international AI agenda at the India AI Summit. Over 2,200 people signed the petition and over 2,000 emails were sent to delegates from 14 different countries. An op-ed was published in Le Nouvel Obs, supported by academic, political and civic figures.',
+				text: 'Pause AI France mobilized to put safety back at the heart of the international AI agenda at the India AI Summit. Over 4,000 people signed the petition and over 2,000 emails were sent to delegates across 14 countries. An op-ed was also published in Le Nouvel Obs.',
 				results: [
-					{ label: 'Petition', value: '4,057 verified signatures' },
+					{ label: 'Petition signatures', value: '4,000+' },
 					{ label: 'Emails to delegates', value: '2,000+ (14 countries)' },
-					{ label: 'Op-ed', value: 'Le Nouvel Obs — 16 Feb. 2026' },
-					{ label: 'Op-ed signatories', value: 'Academic & political figures' }
+					{ label: 'Op-ed', value: 'Le Nouvel Obs' }
 				],
 				link: {
 					label: 'Read the op-ed in Le Nouvel Obs',

--- a/src/lib/campaigns.ts
+++ b/src/lib/campaigns.ts
@@ -58,7 +58,7 @@ export const campaigns: Campaign[] = [
 			fr: {
 				text: "Pause IA a mobilisé pour que le Sommet de l'IA en Inde remette la sécurité au cœur de l'agenda international. Plus de 2 200 personnes ont signé la pétition et plus de 2 000 mails ont été envoyés aux délégués de 14 pays différents. Une tribune a été publiée dans Le Nouvel Obs, soutenue par des personnalités académiques, politiques et associatives.",
 				results: [
-					{ label: 'Pétition', value: '2 200+ signatures' },
+					{ label: 'Pétition', value: '4 057 signatures vérifiées' },
 					{ label: 'Mails aux délégués', value: '2 000+ (14 pays)' },
 					{ label: 'Tribune', value: 'Le Nouvel Obs — 16 fév. 2026' },
 					{ label: 'Signataires tribune', value: 'Personnalités académiques & politiques' }
@@ -71,7 +71,7 @@ export const campaigns: Campaign[] = [
 			en: {
 				text: 'Pause AI France mobilized to put safety back at the heart of the international AI agenda at the India AI Summit. Over 2,200 people signed the petition and over 2,000 emails were sent to delegates from 14 different countries. An op-ed was published in Le Nouvel Obs, supported by academic, political and civic figures.',
 				results: [
-					{ label: 'Petition', value: '2,200+ signatures' },
+					{ label: 'Petition', value: '4,057 verified signatures' },
 					{ label: 'Emails to delegates', value: '2,000+ (14 countries)' },
 					{ label: 'Op-ed', value: 'Le Nouvel Obs — 16 Feb. 2026' },
 					{ label: 'Op-ed signatories', value: 'Academic & political figures' }

--- a/src/routes/[lang=lang]/campagnes/+page.svelte
+++ b/src/routes/[lang=lang]/campagnes/+page.svelte
@@ -170,7 +170,12 @@
 			{/if}
 
 			{#if summary.link}
-				<a href={summary.link.url} target="_blank" rel="noopener noreferrer" class="modal-link">
+				<a
+					href={summary.link.url}
+					target={summary.link.url.startsWith('http') ? '_blank' : undefined}
+					rel="noopener noreferrer"
+					class="modal-link-btn"
+				>
 					{summary.link.label} ↗
 				</a>
 			{/if}
@@ -401,17 +406,27 @@
 		letter-spacing: 0.04em;
 	}
 
-	.modal-link {
-		display: inline-block;
-		margin-top: 1.25rem;
-		font-size: 0.95rem;
+	.modal-link-btn {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.25rem;
+		margin-top: 1.5rem;
+		padding: 0.55rem 1.1rem;
+		border-radius: 999px;
+		font-size: 0.9rem;
 		font-weight: 600;
-		color: var(--brand-subtle, #c96900);
 		text-decoration: none;
+		background: color-mix(in srgb, var(--brand) 12%, var(--bg, #fff));
+		color: var(--brand);
+		border: 1.5px solid color-mix(in srgb, var(--brand) 35%, transparent);
+		transition:
+			background 0.15s,
+			border-color 0.15s;
 	}
 
-	.modal-link:hover {
-		text-decoration: underline;
+	.modal-link-btn:hover {
+		background: color-mix(in srgb, var(--brand) 20%, var(--bg, #fff));
+		border-color: color-mix(in srgb, var(--brand) 55%, transparent);
 	}
 
 	@media (max-width: 600px) {

--- a/src/routes/[lang=lang]/campagnes/+page.svelte
+++ b/src/routes/[lang=lang]/campagnes/+page.svelte
@@ -169,6 +169,27 @@
 				</div>
 			{/if}
 
+			{#if summary.articles?.length}
+				<div class="articles-section">
+					<h3 class="articles-title">{isEn ? 'Press coverage' : 'Couverture presse'}</h3>
+					<ul class="articles-list">
+						{#each summary.articles as article}
+							<li>
+								<a
+									href={article.url}
+									target="_blank"
+									rel="noopener noreferrer"
+									class="article-link"
+								>
+									<span class="article-source">{article.source}</span>
+									<span class="article-title">{article.title}</span>
+								</a>
+							</li>
+						{/each}
+					</ul>
+				</div>
+			{/if}
+
 			{#if summary.link}
 				<a
 					href={summary.link.url}
@@ -404,6 +425,58 @@
 		color: var(--text-secondary, #666);
 		text-transform: uppercase;
 		letter-spacing: 0.04em;
+	}
+
+	.articles-section {
+		margin-top: 1.5rem;
+	}
+
+	.articles-title {
+		font-size: 0.8rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.06em;
+		color: var(--text-secondary, #666);
+		margin: 0 0 0.75rem;
+	}
+
+	.articles-list {
+		list-style: none;
+		padding: 0;
+		margin: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.4rem;
+	}
+
+	.article-link {
+		display: flex;
+		align-items: baseline;
+		gap: 0.6rem;
+		padding: 0.45rem 0.6rem;
+		border-radius: 0.5rem;
+		text-decoration: none;
+		transition: background 0.15s;
+	}
+
+	.article-link:hover {
+		background: var(--bg-subtle, #f5f5f5);
+	}
+
+	.article-source {
+		flex-shrink: 0;
+		font-size: 0.75rem;
+		font-weight: 700;
+		color: var(--brand);
+		background: color-mix(in srgb, var(--brand) 10%, var(--bg, #fff));
+		padding: 0.1rem 0.45rem;
+		border-radius: 999px;
+	}
+
+	.article-title {
+		font-size: 0.9rem;
+		color: var(--text, #222);
+		line-height: 1.4;
 	}
 
 	.modal-link-btn {

--- a/src/routes/[lang=lang]/campagnes/+page.svelte
+++ b/src/routes/[lang=lang]/campagnes/+page.svelte
@@ -4,6 +4,8 @@
 	import Button from '$lib/components/Button.svelte'
 	import { getT } from '$lib/i18n'
 	import { getSortedCampaigns } from '$lib/campaigns'
+	import type { Campaign } from '$lib/campaigns'
+	import { fade } from 'svelte/transition'
 	import type { PageData } from './$types'
 
 	export let data: PageData
@@ -49,7 +51,25 @@
 		const months = isEn ? MONTHS_EN : MONTHS_FR
 		return `${months[m]} ${year}`
 	}
+
+	let selectedCampaign: Campaign | null = null
+
+	function openSummary(campaign: Campaign) {
+		if (campaign.status === 'ended' && campaign.summary) {
+			selectedCampaign = campaign
+		}
+	}
+
+	function closeSummary() {
+		selectedCampaign = null
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') closeSummary()
+	}
 </script>
+
+<svelte:window on:keydown={handleKeydown} />
 
 <PostMeta title={t.campagnes.meta_title} description={t.campagnes.meta_desc} />
 
@@ -67,7 +87,16 @@
 		{#each sortedCampaigns as campaign}
 			{@const content = isEn ? campaign.en : campaign.fr}
 			{@const href = campaign.url ?? `${prefix}/${campaign.slug}`}
-			<div class="campaign-card" class:ended={campaign.status === 'ended'}>
+			{@const hasSummary = campaign.status === 'ended' && campaign.summary}
+			<div
+				class="campaign-card"
+				class:ended={campaign.status === 'ended'}
+				class:clickable={hasSummary}
+				role={hasSummary ? 'button' : undefined}
+				tabindex={hasSummary ? 0 : undefined}
+				on:click={() => hasSummary && openSummary(campaign)}
+				on:keydown={(e) => e.key === 'Enter' && hasSummary && openSummary(campaign)}
+			>
 				<div class="card-top">
 					<div class="card-badge" class:badge-ended={campaign.status === 'ended'}>
 						{campaign.status === 'active' ? t.campagnes.badge_active : t.campagnes.badge_ended}
@@ -84,11 +113,70 @@
 				<p>{content.description}</p>
 				{#if campaign.status === 'active'}
 					<Button {href}>{content.cta}</Button>
+				{:else if hasSummary}
+					<span class="see-results">{isEn ? 'View results' : 'Voir le bilan'} →</span>
 				{/if}
 			</div>
 		{/each}
 	</section>
 </article>
+
+{#if selectedCampaign?.summary}
+	{@const summary = isEn ? selectedCampaign.summary.en : selectedCampaign.summary.fr}
+	{@const content = isEn ? selectedCampaign.en : selectedCampaign.fr}
+	<div
+		class="modal-overlay"
+		role="presentation"
+		on:click={closeSummary}
+		transition:fade={{ duration: 150 }}
+	>
+		<div
+			class="modal"
+			role="dialog"
+			aria-modal="true"
+			aria-label={isEn ? 'Campaign results' : 'Bilan de la campagne'}
+			on:click|stopPropagation
+		>
+			<button class="modal-close" on:click={closeSummary} aria-label={isEn ? 'Close' : 'Fermer'}
+				>&times;</button
+			>
+
+			<div class="modal-header">
+				<div class="card-badge badge-ended">
+					{t.campagnes.badge_ended}
+				</div>
+				<h2>{content.title}</h2>
+				{#if selectedCampaign.startDate}
+					<p class="modal-dates">
+						{formatDate(
+							selectedCampaign.startDate
+						)}{#if selectedCampaign.endDate && selectedCampaign.endDate !== selectedCampaign.startDate}
+							– {formatDate(selectedCampaign.endDate)}{/if}
+					</p>
+				{/if}
+			</div>
+
+			<p class="modal-text">{summary.text}</p>
+
+			{#if summary.results.length > 0}
+				<div class="results-grid">
+					{#each summary.results as result}
+						<div class="result-card">
+							<span class="result-value">{result.value}</span>
+							<span class="result-label">{result.label}</span>
+						</div>
+					{/each}
+				</div>
+			{/if}
+
+			{#if summary.link}
+				<a href={summary.link.url} target="_blank" rel="noopener noreferrer" class="modal-link">
+					{summary.link.label} ↗
+				</a>
+			{/if}
+		</div>
+	</div>
+{/if}
 
 <style>
 	article {
@@ -148,6 +236,17 @@
 		border-color: #eee;
 	}
 
+	.campaign-card.clickable {
+		cursor: pointer;
+	}
+
+	.campaign-card.clickable:hover {
+		opacity: 1;
+		transform: translateY(-2px);
+		box-shadow: 0 8px 32px rgba(0, 0, 0, 0.08);
+		border-color: color-mix(in srgb, var(--brand) 30%, transparent);
+	}
+
 	.active-count {
 		font-size: 1rem;
 		font-weight: 600;
@@ -202,6 +301,119 @@
 		margin-bottom: 1.5rem;
 	}
 
+	.see-results {
+		font-size: 0.9rem;
+		font-weight: 600;
+		color: var(--brand);
+		margin-top: auto;
+	}
+
+	/* Modal */
+	.modal-overlay {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.5);
+		z-index: 2000;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 1rem;
+		backdrop-filter: blur(3px);
+	}
+
+	.modal {
+		background: var(--bg, #fff);
+		border-radius: 1rem;
+		padding: 2.5rem;
+		max-width: 36rem;
+		width: 100%;
+		max-height: 90dvh;
+		overflow-y: auto;
+		position: relative;
+		box-shadow: 0 16px 48px rgba(0, 0, 0, 0.2);
+	}
+
+	.modal-close {
+		position: absolute;
+		top: 1rem;
+		right: 1rem;
+		font-size: 1.75rem;
+		line-height: 1;
+		color: var(--text-secondary, #666);
+		cursor: pointer;
+		padding: 0.25rem 0.5rem;
+		border-radius: 0.5rem;
+		transition: background 0.15s;
+	}
+
+	.modal-close:hover {
+		background: var(--bg-subtle, #f5f5f5);
+	}
+
+	.modal-header {
+		margin-bottom: 1.5rem;
+	}
+
+	.modal-header h2 {
+		font-size: 1.5rem;
+		margin-top: 0.75rem;
+		margin-bottom: 0.25rem;
+	}
+
+	.modal-dates {
+		font-size: 0.9rem;
+		color: #999;
+		margin: 0;
+	}
+
+	.modal-text {
+		font-size: 1rem;
+		line-height: 1.6;
+		margin-bottom: 1.5rem;
+		color: var(--text, #222);
+	}
+
+	.results-grid {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		gap: 0.75rem;
+	}
+
+	.result-card {
+		background: var(--bg-subtle, #f5f5f5);
+		border-radius: 0.75rem;
+		padding: 1rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.result-value {
+		font-weight: 700;
+		font-size: 1rem;
+		color: var(--text, #222);
+	}
+
+	.result-label {
+		font-size: 0.8rem;
+		color: var(--text-secondary, #666);
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+	}
+
+	.modal-link {
+		display: inline-block;
+		margin-top: 1.25rem;
+		font-size: 0.95rem;
+		font-weight: 600;
+		color: var(--brand-subtle, #c96900);
+		text-decoration: none;
+	}
+
+	.modal-link:hover {
+		text-decoration: underline;
+	}
+
 	@media (max-width: 600px) {
 		h2 {
 			font-size: 1.4rem;
@@ -209,6 +421,22 @@
 
 		.campaign-card {
 			padding: 1.5rem;
+		}
+
+		.modal {
+			padding: 1.5rem;
+			border-radius: 1rem 1rem 0 0;
+			max-height: 85dvh;
+			align-self: flex-end;
+		}
+
+		.modal-overlay {
+			align-items: flex-end;
+			padding: 0;
+		}
+
+		.results-grid {
+			grid-template-columns: 1fr;
 		}
 	}
 </style>

--- a/src/routes/[lang=lang]/campagnes/+page.svelte
+++ b/src/routes/[lang=lang]/campagnes/+page.svelte
@@ -438,20 +438,41 @@
 			padding: 1.5rem;
 		}
 
-		.modal {
-			padding: 1.5rem;
-			border-radius: 1rem 1rem 0 0;
-			max-height: 85dvh;
-			align-self: flex-end;
-		}
-
 		.modal-overlay {
 			align-items: flex-end;
 			padding: 0;
 		}
 
+		.modal {
+			width: 100%;
+			max-width: 100%;
+			max-height: 88dvh;
+			border-radius: 1.25rem 1.25rem 0 0;
+			padding: 1.25rem 1.25rem calc(1.25rem + env(safe-area-inset-bottom));
+		}
+
+		.modal::before {
+			content: '';
+			display: block;
+			width: 2.5rem;
+			height: 0.25rem;
+			background: #ccc;
+			border-radius: 999px;
+			margin: 0 auto 1.25rem;
+		}
+
+		.modal-close {
+			top: 0.75rem;
+			right: 0.75rem;
+		}
+
 		.results-grid {
-			grid-template-columns: 1fr;
+			grid-template-columns: 1fr 1fr;
+		}
+
+		.modal-link-btn {
+			width: 100%;
+			justify-content: center;
 		}
 	}
 </style>

--- a/src/routes/campagnes/+page.svelte
+++ b/src/routes/campagnes/+page.svelte
@@ -1,12 +1,34 @@
 <script lang="ts">
 	import PostMeta from '$components/PostMeta.svelte'
 	import UnderlinedTitle from '$components/UnderlinedTitle.svelte'
-	import Button from '$lib/components/Button.svelte'
+	import { getSortedCampaigns } from '$lib/campaigns'
+	import type { Campaign } from '$lib/campaigns'
+	import { fade } from 'svelte/transition'
 
 	const title = 'Nos Campagnes'
 	const description =
-		'Découvrez les campagnes menées par notre association pour sensibiliser et agir face aux risques de l’IA.'
+		'Découvrez les campagnes menées par notre association pour sensibiliser et agir face aux risques de l\u2019IA.'
+
+	const campaigns = getSortedCampaigns()
+
+	let selectedCampaign: Campaign | null = null
+
+	function openSummary(campaign: Campaign) {
+		if (campaign.status === 'ended' && campaign.summary) {
+			selectedCampaign = campaign
+		}
+	}
+
+	function closeSummary() {
+		selectedCampaign = null
+	}
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') closeSummary()
+	}
 </script>
+
+<svelte:window on:keydown={handleKeydown} />
 
 <PostMeta {title} {description} />
 
@@ -19,22 +41,73 @@
 	</section>
 
 	<section class="campaigns-grid">
-		<div class="campaign-card ended">
-			<span class="badge badge-ended">Terminée</span>
-			<h2>Élections municipales 2026</h2>
-			<p>Sensibilisons nos futurs élus locaux et demandons-leur de signer la charte Pause IA.</p>
-		</div>
-
-		<div class="campaign-card ended">
-			<span class="badge badge-ended">Terminée</span>
-			<h2>Sommet de l'IA 2026</h2>
-			<p>
-				Mobilisons-nous pour que le Sommet international de l'IA en Inde place la sécurité au
-				premier plan.
-			</p>
-		</div>
+		{#each campaigns as campaign}
+			{@const info = campaign.fr}
+			{@const hasSummary = campaign.status === 'ended' && campaign.summary}
+			<button
+				class="campaign-card"
+				class:ended={campaign.status === 'ended'}
+				class:clickable={hasSummary}
+				on:click={() => openSummary(campaign)}
+				disabled={!hasSummary}
+			>
+				{#if campaign.status === 'ended'}
+					<span class="badge badge-ended">Terminée</span>
+				{:else}
+					<span class="badge badge-active">En cours</span>
+				{/if}
+				<h2>{info.title}</h2>
+				<p>{info.description}</p>
+				{#if hasSummary}
+					<span class="see-results">Voir le bilan</span>
+				{/if}
+			</button>
+		{/each}
 	</section>
 </article>
+
+{#if selectedCampaign?.summary}
+	<div
+		class="modal-overlay"
+		role="presentation"
+		on:click={closeSummary}
+		transition:fade={{ duration: 150 }}
+	>
+		<div
+			class="modal"
+			role="dialog"
+			aria-modal="true"
+			aria-label="Bilan de la campagne"
+			on:click|stopPropagation
+		>
+			<button class="modal-close" on:click={closeSummary} aria-label="Fermer">&times;</button>
+
+			<div class="modal-header">
+				<span class="badge badge-ended">Terminée</span>
+				<h2>{selectedCampaign.fr.title}</h2>
+				{#if selectedCampaign.startDate}
+					<p class="modal-dates">
+						{selectedCampaign.startDate}{#if selectedCampaign.endDate && selectedCampaign.endDate !== selectedCampaign.startDate}
+							&ndash; {selectedCampaign.endDate}{/if}
+					</p>
+				{/if}
+			</div>
+
+			<p class="modal-text">{selectedCampaign.summary.fr.text}</p>
+
+			{#if selectedCampaign.summary.fr.results.length > 0}
+				<div class="results-grid">
+					{#each selectedCampaign.summary.fr.results as result}
+						<div class="result-card">
+							<span class="result-value">{result.value}</span>
+							<span class="result-label">{result.label}</span>
+						</div>
+					{/each}
+				</div>
+			{/if}
+		</div>
+	</div>
+{/if}
 
 <style>
 	article {
@@ -70,12 +143,26 @@
 		box-shadow: 0 4px 20px rgba(0, 0, 0, 0.03);
 		display: flex;
 		flex-direction: column;
-		justify-content: space-between;
 		align-items: flex-start;
+		text-align: left;
+		cursor: default;
+		width: 100%;
 	}
 
 	.campaign-card.ended {
 		opacity: 0.75;
+	}
+
+	.campaign-card.clickable {
+		cursor: pointer;
+		transition:
+			opacity 0.2s,
+			box-shadow 0.2s;
+	}
+
+	.campaign-card.clickable:hover {
+		opacity: 1;
+		box-shadow: 0 6px 24px rgba(0, 0, 0, 0.08);
 	}
 
 	.badge {
@@ -94,6 +181,11 @@
 		color: #888;
 	}
 
+	.badge-active {
+		background: color-mix(in srgb, var(--brand) 15%, white);
+		color: var(--brand);
+	}
+
 	h2 {
 		font-size: 1.75rem;
 		margin-top: 0;
@@ -104,13 +196,132 @@
 	.campaign-card p {
 		font-size: 1.1rem;
 		line-height: 1.6;
-		margin-bottom: 2rem;
+		margin-bottom: 1.5rem;
 		color: var(--text-secondary);
+	}
+
+	.see-results {
+		font-size: 0.9rem;
+		font-weight: 600;
+		color: var(--brand);
+		margin-top: auto;
+	}
+
+	.campaign-card.clickable:hover .see-results {
+		text-decoration: underline;
+	}
+
+	/* Modal */
+	.modal-overlay {
+		position: fixed;
+		inset: 0;
+		background: rgba(0, 0, 0, 0.5);
+		z-index: 2000;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 1rem;
+		backdrop-filter: blur(3px);
+	}
+
+	.modal {
+		background: var(--bg);
+		border-radius: 1rem;
+		padding: 2.5rem;
+		max-width: 36rem;
+		width: 100%;
+		max-height: 90dvh;
+		overflow-y: auto;
+		position: relative;
+		box-shadow: 0 16px 48px rgba(0, 0, 0, 0.2);
+	}
+
+	.modal-close {
+		position: absolute;
+		top: 1rem;
+		right: 1rem;
+		font-size: 1.75rem;
+		line-height: 1;
+		color: var(--text-secondary);
+		cursor: pointer;
+		padding: 0.25rem 0.5rem;
+		border-radius: 0.5rem;
+		transition: background 0.15s;
+	}
+
+	.modal-close:hover {
+		background: var(--bg-subtle);
+	}
+
+	.modal-header {
+		margin-bottom: 1.5rem;
+	}
+
+	.modal-header h2 {
+		font-size: 1.5rem;
+		margin-bottom: 0.25rem;
+	}
+
+	.modal-dates {
+		font-size: 0.9rem;
+		color: var(--text-secondary);
+		margin: 0;
+	}
+
+	.modal-text {
+		font-size: 1rem;
+		line-height: 1.6;
+		margin-bottom: 1.5rem;
+		color: var(--text);
+	}
+
+	.results-grid {
+		display: grid;
+		grid-template-columns: repeat(2, 1fr);
+		gap: 0.75rem;
+	}
+
+	.result-card {
+		background: var(--bg-subtle);
+		border-radius: 0.75rem;
+		padding: 1rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.result-value {
+		font-weight: 700;
+		font-size: 1rem;
+		color: var(--text);
+	}
+
+	.result-label {
+		font-size: 0.8rem;
+		color: var(--text-secondary);
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
 	}
 
 	@media (max-width: 600px) {
 		.campaign-card {
 			padding: 1.5rem;
+		}
+
+		.modal {
+			padding: 1.5rem;
+			border-radius: 1rem 1rem 0 0;
+			max-height: 85dvh;
+			align-self: flex-end;
+		}
+
+		.modal-overlay {
+			align-items: flex-end;
+			padding: 0;
+		}
+
+		.results-grid {
+			grid-template-columns: 1fr;
 		}
 	}
 </style>

--- a/src/routes/campagnes/+page.svelte
+++ b/src/routes/campagnes/+page.svelte
@@ -105,6 +105,17 @@
 					{/each}
 				</div>
 			{/if}
+
+			{#if selectedCampaign.summary.fr.link}
+				<a
+					href={selectedCampaign.summary.fr.link.url}
+					target="_blank"
+					rel="noopener noreferrer"
+					class="modal-link"
+				>
+					{selectedCampaign.summary.fr.link.label} ↗
+				</a>
+			{/if}
 		</div>
 	</div>
 {/if}
@@ -301,6 +312,19 @@
 		color: var(--text-secondary);
 		text-transform: uppercase;
 		letter-spacing: 0.04em;
+	}
+
+	.modal-link {
+		display: inline-block;
+		margin-top: 1.25rem;
+		font-size: 0.95rem;
+		font-weight: 600;
+		color: var(--brand-subtle);
+		text-decoration: none;
+	}
+
+	.modal-link:hover {
+		text-decoration: underline;
 	}
 
 	@media (max-width: 600px) {


### PR DESCRIPTION
- Ajout d'un type CampaignSummary dans campaigns.ts avec texte + résultats chiffrés
- Municipales 2026 : 12 signataires, 11 villes, 7 chartes complètes, 10 articles presse
- Sommet IA 2026 : relais pétition internationale, interpellations
- Page campagnes : cartes cliquables pour les campagnes terminées avec bilan
- Popup modal avec résumé + grille de résultats chiffrés
- Mobile : popup en bottom sheet, desktop : centré
- Fermeture par clic overlay, bouton close ou Escape

