### PR TITLE
[BUG] Limit to 2000 character the length of testimony

### DIFF
--- a/src/routes/[lang=lang]/emploi-ia/questionnaire/+page.svelte
+++ b/src/routes/[lang=lang]/emploi-ia/questionnaire/+page.svelte
@@ -576,6 +576,7 @@
 						bind:value={formData.temoignage}
 						rows="6"
 						placeholder={t.emploi_questionnaire.section3.placeholder_temoignage}
+						maxlength={2000}
 					></textarea>
 				</div>
 

--- a/src/routes/emploi-ia/questionnaire/+page.svelte
+++ b/src/routes/emploi-ia/questionnaire/+page.svelte
@@ -526,6 +526,7 @@
 						bind:value={formData.temoignage}
 						rows="6"
 						placeholder="Comment l'IA impacte-t-elle votre vie professionnelle ? Vous pouvez témoigner de votre vécu : aspects positifs ou négatifs ? Qu'avez-vous expérimenté, accepté, refusé ? Comment vos tâches se sont-elles modifiées ? Cela vous a-t-il demandé d'acquérir des compétences ou d'abandonner certaines parties de votre métier ? Avez-vous dû changer de poste, démissionner, vous reconvertir ? Quelles questions vous posez-vous ? Bref, tout nous intéresse ici."
+						maxlength={2000}
 					></textarea>
 				</div>
 


### PR DESCRIPTION
J'ai mis une limite de 2000 charactères pour la taille des témoignages car c'est la longueur maximal qu'une valeur de type rich_text peut avoir sur notion, et que sans cela les utilisateurs ont un bug si leur témoignage est trop long et ne peuvent pas valider le questionnaire.