### PR TITLE
Add analyses section with 2 article cards to emploi-ia page

### DIFF
--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -504,17 +504,15 @@ export default {
 		articles_lang_fr: 'French',
 		articles_lang_en: 'English',
 		analyses_section_title: 'Our analyses',
-		analyses_section_text:
-			'Our members have written in-depth analyses on the impact of AI on employment and our social model.',
-		analyses_read: 'Read the analysis',
-		article1_title: "AI won't just destroy your job: a threat to our social model",
+		analyses_section_text: 'Two in-depth articles on AI and employment, written by our members.',
+		analyses_read: 'Read',
+		article1_title: 'Replacing humans is the goal',
 		article1_desc:
-			'Generative AI threatens not only our individual jobs, but also the foundations of our socio-economic model: social contributions, purchasing power and national sovereignty.',
-		article1_url:
-			'/newsletters/lia-ne-detruira-pas-que-votre-emploi-menace-sur-notre-modele-de-societe',
-		article2_title: 'Replacing humans is the goal',
+			'In a few years, AI has become capable of replacing humans in more and more tasks — 16% of work in France already automatable.',
+		article1_url: '/emploi-ia/remplacer-humain',
+		article2_title: 'France: no pilot in the cockpit',
 		article2_desc:
-			'Behind the scientific adventure of AI lies a clear goal: to replace humans in a growing number of tasks. What are the consequences for our work and our social model?',
-		article2_url: '/emploi-ia/remplacer-humain'
+			'Mass youth unemployment, a threatened welfare state, dependence on Silicon Valley: what our world could look like if we fail to act.',
+		article2_url: '/emploi-ia/pas-de-pilote'
 	}
 }

--- a/src/lib/i18n/en.ts
+++ b/src/lib/i18n/en.ts
@@ -502,6 +502,19 @@ export default {
 		articles_lang_label: 'Language:',
 		articles_lang_all: 'All',
 		articles_lang_fr: 'French',
-		articles_lang_en: 'English'
+		articles_lang_en: 'English',
+		analyses_section_title: 'Our analyses',
+		analyses_section_text:
+			'Our members have written in-depth analyses on the impact of AI on employment and our social model.',
+		analyses_read: 'Read the analysis',
+		article1_title: "AI won't just destroy your job: a threat to our social model",
+		article1_desc:
+			'Generative AI threatens not only our individual jobs, but also the foundations of our socio-economic model: social contributions, purchasing power and national sovereignty.',
+		article1_url:
+			'/newsletters/lia-ne-detruira-pas-que-votre-emploi-menace-sur-notre-modele-de-societe',
+		article2_title: 'Replacing humans is the goal',
+		article2_desc:
+			'Behind the scientific adventure of AI lies a clear goal: to replace humans in a growing number of tasks. What are the consequences for our work and our social model?',
+		article2_url: '/emploi-ia/remplacer-humain'
 	}
 }

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -507,17 +507,15 @@ export default {
 		articles_lang_fr: 'Français',
 		articles_lang_en: 'Anglais',
 		analyses_section_title: 'Nos analyses',
-		analyses_section_text:
-			"Nos membres ont rédigé des analyses approfondies sur l'impact de l'IA sur l'emploi et notre modèle de société.",
-		analyses_read: "Lire l'analyse",
-		article1_title: "L'IA ne détruira pas que votre emploi : menace sur notre modèle de société",
+		analyses_section_text: "Deux articles de fond sur l'IA et l'emploi, rédigés par nos membres.",
+		analyses_read: 'Lire',
+		article1_title: "Remplacer l'humain, tel est l'objectif",
 		article1_desc:
-			"L'IA générative menace non seulement nos emplois individuels, mais aussi les fondements de notre modèle socio-économique : cotisations sociales, pouvoir d'achat et souveraineté nationale.",
-		article1_url:
-			'/newsletters/lia-ne-detruira-pas-que-votre-emploi-menace-sur-notre-modele-de-societe',
-		article2_title: "Remplacer l'humain, tel est l'objectif",
+			"En quelques années, l'IA est devenue capable de remplacer les humains dans des tâches de plus en plus nombreuses — 16 % du travail déjà automatisable en France.",
+		article1_url: '/emploi-ia/remplacer-humain',
+		article2_title: "Pas de pilote dans l'avion France",
 		article2_desc:
-			"Derrière l'aventure scientifique de l'IA se cache un objectif clair : remplacer les humains dans un nombre croissant de tâches. Quelles en sont les conséquences pour notre travail et notre modèle de société ?",
-		article2_url: '/emploi-ia/remplacer-humain'
+			'Chômage massif des jeunes, modèle social fragilisé, dépendance à la Silicon Valley : à quoi ressemblera notre monde si nous ne réagissons pas.',
+		article2_url: '/emploi-ia/pas-de-pilote'
 	}
 }

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -505,6 +505,19 @@ export default {
 		articles_lang_label: 'Langue :',
 		articles_lang_all: 'Toutes',
 		articles_lang_fr: 'Français',
-		articles_lang_en: 'Anglais'
+		articles_lang_en: 'Anglais',
+		analyses_section_title: 'Nos analyses',
+		analyses_section_text:
+			"Nos membres ont rédigé des analyses approfondies sur l'impact de l'IA sur l'emploi et notre modèle de société.",
+		analyses_read: "Lire l'analyse",
+		article1_title: "L'IA ne détruira pas que votre emploi : menace sur notre modèle de société",
+		article1_desc:
+			"L'IA générative menace non seulement nos emplois individuels, mais aussi les fondements de notre modèle socio-économique : cotisations sociales, pouvoir d'achat et souveraineté nationale.",
+		article1_url:
+			'/newsletters/lia-ne-detruira-pas-que-votre-emploi-menace-sur-notre-modele-de-societe',
+		article2_title: "Remplacer l'humain, tel est l'objectif",
+		article2_desc:
+			"Derrière l'aventure scientifique de l'IA se cache un objectif clair : remplacer les humains dans un nombre croissant de tâches. Quelles en sont les conséquences pour notre travail et notre modèle de société ?",
+		article2_url: '/emploi-ia/remplacer-humain'
 	}
 }

--- a/src/lib/i18n/fr.ts
+++ b/src/lib/i18n/fr.ts
@@ -511,7 +511,7 @@ export default {
 		analyses_read: 'Lire',
 		article1_title: "Remplacer l'humain, tel est l'objectif",
 		article1_desc:
-			"En quelques années, l'IA est devenue capable de remplacer les humains dans des tâches de plus en plus nombreuses — 16 % du travail déjà automatisable en France.",
+			"En quelques années, l'IA est devenue capable de remplacer les humains dans des tâches de plus en plus nombreuses, 16 % du travail déjà automatisable en France.",
 		article1_url: '/emploi-ia/remplacer-humain',
 		article2_title: "Pas de pilote dans l'avion France",
 		article2_desc:

--- a/src/routes/[lang=lang]/emploi-ia/+page.svelte
+++ b/src/routes/[lang=lang]/emploi-ia/+page.svelte
@@ -113,11 +113,13 @@
 		<p>{t.emploi_ia.analyses_section_text}</p>
 		<div class="article-cards">
 			<a class="article-card" href={t.emploi_ia.article1_url}>
+				<span class="card-meta">Article 1/2 &middot; 4 min</span>
 				<h3 class="article-card-title">{t.emploi_ia.article1_title}</h3>
 				<p class="article-card-desc">{t.emploi_ia.article1_desc}</p>
 				<span class="article-card-link">{t.emploi_ia.analyses_read} &rarr;</span>
 			</a>
 			<a class="article-card" href={t.emploi_ia.article2_url}>
+				<span class="card-meta">Article 2/2 &middot; 5 min</span>
 				<h3 class="article-card-title">{t.emploi_ia.article2_title}</h3>
 				<p class="article-card-desc">{t.emploi_ia.article2_desc}</p>
 				<span class="article-card-link">{t.emploi_ia.analyses_read} &rarr;</span>
@@ -255,10 +257,17 @@
 		margin-top: 1.5rem;
 	}
 
+	.card-meta {
+		font-size: 0.75rem;
+		font-weight: 600;
+		color: var(--text-secondary, #888);
+		letter-spacing: 0.04em;
+	}
+
 	.article-card {
 		display: flex;
 		flex-direction: column;
-		gap: 0.75rem;
+		gap: 0.6rem;
 		padding: 1.25rem 1.5rem;
 		border: 1px solid var(--border, #e5e7eb);
 		border-radius: 10px;

--- a/src/routes/[lang=lang]/emploi-ia/+page.svelte
+++ b/src/routes/[lang=lang]/emploi-ia/+page.svelte
@@ -108,6 +108,23 @@
 		<TestimonialCarousel {testimonials} {lang} />
 	</section>
 
+	<section id="analyses" aria-labelledby="analyses-heading">
+		<h2 id="analyses-heading">{t.emploi_ia.analyses_section_title}</h2>
+		<p>{t.emploi_ia.analyses_section_text}</p>
+		<div class="article-cards">
+			<a class="article-card" href={t.emploi_ia.article1_url}>
+				<h3 class="article-card-title">{t.emploi_ia.article1_title}</h3>
+				<p class="article-card-desc">{t.emploi_ia.article1_desc}</p>
+				<span class="article-card-link">{t.emploi_ia.analyses_read} &rarr;</span>
+			</a>
+			<a class="article-card" href={t.emploi_ia.article2_url}>
+				<h3 class="article-card-title">{t.emploi_ia.article2_title}</h3>
+				<p class="article-card-desc">{t.emploi_ia.article2_desc}</p>
+				<span class="article-card-link">{t.emploi_ia.analyses_read} &rarr;</span>
+			</a>
+		</div>
+	</section>
+
 	<section id="bigger-problem" aria-labelledby="bigger-problem-heading" class="bigger-problem">
 		<h2 id="bigger-problem-heading">{t.emploi_ia.bigger_problem_title}</h2>
 		<p>{t.emploi_ia.bigger_problem_text_1}</p>
@@ -228,6 +245,60 @@
 		.stat-number {
 			font-size: 2.2rem;
 		}
+	}
+
+	/* ── Article cards ── */
+	.article-cards {
+		display: grid;
+		grid-template-columns: repeat(auto-fill, minmax(min(280px, 100%), 1fr));
+		gap: 1.25rem;
+		margin-top: 1.5rem;
+	}
+
+	.article-card {
+		display: flex;
+		flex-direction: column;
+		gap: 0.75rem;
+		padding: 1.25rem 1.5rem;
+		border: 1px solid var(--border, #e5e7eb);
+		border-radius: 10px;
+		background: var(--bg-card, #fafafa);
+		text-decoration: none;
+		color: inherit;
+		transition:
+			border-color 0.2s,
+			box-shadow 0.2s;
+	}
+
+	.article-card:hover {
+		border-color: var(--brand, #ff9416);
+		box-shadow: 0 2px 12px rgba(255, 148, 22, 0.12);
+	}
+
+	.article-card-title {
+		font-size: 1rem;
+		font-weight: 700;
+		line-height: 1.4;
+		color: var(--text, #111);
+		margin: 0;
+	}
+
+	.article-card-desc {
+		font-size: 0.9rem;
+		color: var(--text-secondary, #676e7a);
+		line-height: 1.5;
+		margin: 0;
+		flex: 1;
+	}
+
+	.article-card-link {
+		font-size: 0.875rem;
+		font-weight: 600;
+		color: var(--brand-subtle, #c96900);
+	}
+
+	.article-card:hover .article-card-link {
+		color: var(--brand, #ff9416);
 	}
 
 	/* ── Bigger-problem section ── */

--- a/src/routes/[lang=lang]/emploi-ia/pas-de-pilote/+page.svelte
+++ b/src/routes/[lang=lang]/emploi-ia/pas-de-pilote/+page.svelte
@@ -1,0 +1,296 @@
+<script lang="ts">
+	import UnderlinedTitle from '$components/UnderlinedTitle.svelte'
+	import type { Lang } from '$lib/i18n'
+
+	export let data: { lang: Lang }
+</script>
+
+<svelte:head>
+	<title>Pas de pilote dans l'avion France | PauseAI France</title>
+	<meta
+		name="description"
+		content="Chômage massif des jeunes, modèle social fragilisé, dépendance à la Silicon Valley : à quoi ressemblera notre monde si nous ne réagissons pas à la montée de l'IA."
+	/>
+	<meta name="robots" content="index, follow" />
+</svelte:head>
+
+<article>
+	<nav class="breadcrumb">
+		<a href="/{data.lang}/emploi-ia">← Campagne Emploi &amp; IA</a>
+	</nav>
+
+	<div class="article-meta">
+		<span class="meta-tag">Analyse</span>
+		<span class="meta-sep">·</span>
+		<span class="meta-series">Article 2/2</span>
+		<span class="meta-sep">·</span>
+		<span class="meta-reading">5 min de lecture</span>
+	</div>
+
+	<hgroup>
+		<UnderlinedTitle as="h1">Pas de pilote dans l'avion France</UnderlinedTitle>
+	</hgroup>
+
+	<p class="intro">
+		Avec une IA hors de contrôle, qu'est-ce qui pourrait mal se passer pour notre modèle économique
+		et social ?
+	</p>
+
+	<p>
+		Aucune limite n'arrête pour le moment les géants américains de la tech, ni réglementaire, ni
+		capitalistique, ni physique (énergie). Le développement des modèles d'IA de pointe se poursuit
+		donc, sans autre intention que de les rendre capables de faire aussi bien ou mieux que les
+		humains dans quasiment tous les domaines. Avec, à la clé, la promesse d'une croissance
+		économique à deux chiffres, nécessaire pour assurer la rentabilité future des capitaux investis,
+		mais dont le contenu reste pour le moins flou.
+	</p>
+
+	<h2>À tâtons dans le brouillard</h2>
+
+	<p>
+		Alors, cette croissance ? Il paraît clair que l'IA puisse être plus productive que les humains
+		dans des tâches de plus en plus nombreuses, et par là augmenter les bénéfices des entreprises.
+		On veut bien admettre qu'elle puisse rendre le travail plus intéressant pour les humains en les
+		« augmentant » (mais ça peut aussi être l'inverse). On voit aussi que, même si le processus peut
+		être complexe, le déploiement de l'IA dans les entreprises semble déjà inévitable dans de
+		nombreux domaines : celles qui ne l'utiliseront pas ne pourront pas résister à la concurrence.
+		On verra même se créer des entreprises entièrement pilotées par l'IA, sans employé ou presque.
+	</p>
+
+	<p>
+		Au-delà de ces généralités, personne ne sait dire à quoi l'économie de demain ressemblera, sinon
+		qu'il y aura moins d'humains occupés à des tâches purement intellectuelles ou, à terme, purement
+		manuelles (le développement de la robotique étant également boosté par les progrès de
+		l'intelligence artificielle). L'avenir se laisse d'autant moins appréhender que le moteur de
+		cette mutation est une technologie littéralement incontrôlée, dont les « progrès » vont de pair
+		avec une insécurité croissante.
+	</p>
+
+	<p>
+		Faut-il croire les optimistes pour qui la révolution de l'IA, comme les révolutions
+		industrielles avant elle, va supprimer des emplois pour mieux en créer d'autres et finalement
+		déboucher sur une plus grande prospérité (théorie de la destruction créatrice) ? Non car cette
+		révolution-là est beaucoup plus rapide que les précédentes : tout va beaucoup trop vite, sans
+		stratégie industrielle claire, sans amortisseur social, sans réorientation rapide de notre
+		système éducatif.
+	</p>
+
+	<h2>Le scénario le plus probable : un chômage massif et brutal</h2>
+
+	<p>
+		Dans un premier temps, ce seront surtout les jeunes qui ne trouveront plus d'emploi. Les tâches
+		habituellement confiées à des juniors seront de plus en plus effectuées par l'IA, laquelle sera
+		mise en place et contrôlée par des personnes expérimentées. Outre les préjudices causés aux
+		individus de cette génération, les conséquences systémiques sont graves : les diplômes se
+		démonétisent puisqu'ils ne procurent plus d'emploi. Sans emploi, l'acquisition d'expérience
+		devient impossible, de même que la transmission des plus âgés vers les plus jeunes.
+	</p>
+
+	<p>
+		À la différence de crises précédentes (désindustrialisation, automatisation, informatique,
+		mondialisation) qui ont touché progressivement des travailleurs peu qualifiés ou très
+		spécialisés, les premières tâches automatisables par l'IA sont celles effectuées par des
+		professions intellectuelles aux salaires relativement élevés par rapport à la moyenne. C'est
+		donc un volume important de recettes de cotisations sociales qui est menacé de volatilisation à
+		court terme. L'évolution dépend ensuite des progrès de l'IA, susceptibles de monter à nouveau en
+		flèche et entraînant une nouvelle vague d'automatisation.
+	</p>
+
+	<h2>Notre modèle socio-économique en jeu</h2>
+
+	<p>
+		Il est impensable, dans une économie sans ligne directrice claire, que les personnes déclassées
+		par l'IA puissent acquérir en quelques mois de nouvelles compétences non remplaçables par l'IA
+		(si elles les acquièrent jamais) et trouver un nouvel emploi.
+	</p>
+
+	<p>
+		Ce qui est certain en revanche, c'est qu'une fonte rapide et irréversible des revenus du travail
+		remettrait en cause notre modèle de société. Schématiquement, moins de travail, c'est moins de
+		cotisations sociales donc moins d'argent pour assurer le versement de prestations (assurance
+		chômage, maladie, retraite…). C'est moins de revenus pour vivre, pour consommer et pour faire
+		tourner l'économie des biens et services de consommation.
+	</p>
+
+	<p>
+		Même Sam Altman, le PDG d'OpenAI, s'en inquiète. Dans une note publiée en avril 2026, il enjoint
+		aux pouvoirs publics de considérer des solutions telles qu'un revenu de remplacement, la
+		création d'un fonds alimenté par les entreprises de la tech, ou d'autres.
+	</p>
+
+	<h2>Dépendance inacceptable</h2>
+
+	<p>
+		Méditons sur cette perspective : voulons-nous que nos vies dépendent des revenus d'entreprises
+		hyper-puissantes, dont les produits ont par ailleurs des effets délétères sur nos démocraties,
+		nos cerveaux, notre santé mentale, nos ressources naturelles ? Ou préférons-nous garder le
+		contrôle de notre économie et de notre modèle social ?
+	</p>
+
+	<p>
+		Mais au fond, quel contrôle nous reste-t-il, et comment le conserver ? Dans un monde où la
+		croissance économique dépendra de moins en moins du travail et de plus en plus du capital
+		investi dans l'intelligence artificielle et ses infrastructures, ce sont les revenus de ce
+		capital qui devront être redistribués. Qui décidera si ce capital sera investi dans la santé
+		pour tous et la transition écologique ou dans la guerre et la colonisation de la planète Mars ?
+	</p>
+
+	<p>
+		Derrière la question de l'emploi, c'est véritablement notre monde qui est en jeu. Il faut bien
+		comprendre que les progrès de l'intelligence artificielle générale accélèrent de manière
+		incontrôlée la destruction de notre modèle socio-économique, pour le remplacer par une
+		dépendance gravissime à la superpuissance de la Silicon Valley, des États-Unis et de la Chine.
+	</p>
+
+	<p>
+		Cette perte de souveraineté n'est pas acceptable : nous demandons un moratoire international sur
+		l'entraînement des modèles d'intelligence artificielle de pointe, le temps nécessaire pour que
+		les conditions de sécurité et de contrôle démocratique soient réunies.
+	</p>
+
+	<div class="cta-box">
+		<p class="cta-text">Vous aussi, agissez pour un développement de l'IA sûr et démocratique.</p>
+		<a href="/{data.lang}/emploi-ia" class="cta-btn">Je participe à la campagne</a>
+	</div>
+
+	<nav class="article-nav">
+		<a href="/{data.lang}/emploi-ia/remplacer-humain" class="nav-prev"
+			>← Remplacer l'humain, tel est l'objectif</a
+		>
+		<a href="/{data.lang}/emploi-ia" class="nav-back">Campagne Emploi &amp; IA</a>
+	</nav>
+</article>
+
+<style>
+	article {
+		max-inline-size: 50rem;
+		margin-inline: auto;
+		margin-top: 2rem;
+		padding: 0 1rem;
+	}
+
+	.breadcrumb {
+		margin-bottom: 1.5rem;
+	}
+
+	.breadcrumb a {
+		font-size: 0.875rem;
+		color: var(--text-secondary, #676e7a);
+		text-decoration: none;
+		transition: color 0.2s;
+	}
+
+	.breadcrumb a:hover {
+		color: var(--brand, #ff9416);
+	}
+
+	.article-meta {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		margin-bottom: 1.25rem;
+		flex-wrap: wrap;
+	}
+
+	.meta-tag {
+		font-size: 0.7rem;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--brand-subtle, #c96900);
+		background: var(--brand-light, #fff5e8);
+		padding: 0.2rem 0.55rem;
+		border-radius: 4px;
+	}
+
+	.meta-sep {
+		color: var(--border, #d1d5db);
+		font-size: 0.8rem;
+	}
+
+	.meta-series {
+		font-size: 0.8125rem;
+		font-weight: 600;
+		color: var(--text-secondary, #555);
+	}
+
+	.meta-reading {
+		font-size: 0.8125rem;
+		color: var(--text-secondary, #888);
+	}
+
+	.intro {
+		font-size: 1.15rem;
+		font-weight: 500;
+		color: var(--brand-subtle, #c96900);
+		border-left: 4px solid var(--brand, #ff9416);
+		background: var(--brand-light, #fff5e8);
+		padding: 1rem 1.25rem;
+		margin: 1.5rem 0 2rem;
+	}
+
+	h2 {
+		margin-top: 2.5rem;
+	}
+
+	.cta-box {
+		margin: 3rem 0 2rem;
+		padding: 2rem;
+		background: var(--brand-light, #fff5e8);
+		border-left: 4px solid var(--brand, #ff9416);
+		border-radius: 0 12px 12px 0;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 1rem;
+	}
+
+	.cta-text {
+		font-weight: 600;
+		color: var(--brand-subtle, #c96900);
+		margin: 0;
+	}
+
+	.cta-btn {
+		display: inline-block;
+		background: var(--brand, #ff9416);
+		color: white;
+		text-decoration: none;
+		padding: 0.75rem 1.5rem;
+		border-radius: 6px;
+		font-weight: 600;
+		transition: background 0.2s;
+	}
+
+	.cta-btn:hover {
+		background: var(--btn-hover-bg, #ffa945);
+		color: white;
+	}
+
+	.article-nav {
+		margin-top: 2rem;
+		padding-top: 1.5rem;
+		border-top: 1px solid var(--border, #e5e7eb);
+		margin-bottom: 3rem;
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: 0.75rem;
+	}
+
+	.article-nav a {
+		color: var(--text-secondary, #676e7a);
+		text-decoration: none;
+		font-size: 0.9375rem;
+		transition: color 0.2s;
+	}
+
+	.article-nav a:hover {
+		color: var(--brand, #ff9416);
+	}
+
+	.nav-back {
+		font-size: 0.875rem !important;
+	}
+</style>

--- a/src/routes/[lang=lang]/emploi-ia/pas-de-pilote/+page.ts
+++ b/src/routes/[lang=lang]/emploi-ia/pas-de-pilote/+page.ts
@@ -1,0 +1,9 @@
+import type { PageLoad, EntryGenerator } from './$types'
+
+export const prerender = true
+
+export const entries: EntryGenerator = () => [{ lang: 'fr' }, { lang: 'en' }]
+
+export const load: PageLoad = ({ params }) => {
+	return { lang: params.lang }
+}

--- a/src/routes/[lang=lang]/emploi-ia/remplacer-humain/+page.svelte
+++ b/src/routes/[lang=lang]/emploi-ia/remplacer-humain/+page.svelte
@@ -1,0 +1,311 @@
+<script lang="ts">
+	import UnderlinedTitle from '$components/UnderlinedTitle.svelte'
+	import type { Lang } from '$lib/i18n'
+
+	export let data: { lang: Lang }
+</script>
+
+<svelte:head>
+	<title>Remplacer l'humain, tel est l'objectif | PauseAI France</title>
+	<meta
+		name="description"
+		content="Derrière l'aventure scientifique fascinante de l'intelligence artificielle, c'est bien la prise de contrôle de nos vies, à commencer par notre travail, qui est en jeu."
+	/>
+	<meta name="robots" content="index, follow" />
+</svelte:head>
+
+<article>
+	<hgroup>
+		<UnderlinedTitle as="h1">Remplacer l'humain, tel est l'objectif</UnderlinedTitle>
+	</hgroup>
+
+	<p class="intro">
+		Derrière l'aventure scientifique fascinante de l'intelligence artificielle, c'est bien la prise
+		de contrôle de nos vies, à commencer par notre travail, qui est en jeu.
+	</p>
+
+	<p>
+		En l'espace de quelques années, les modèles d'intelligence artificielle de pointe tels que GPT
+		(développé par OpenAI, plus connu sous le nom de son agent conversationnel ChatGPT), Claude
+		(Anthropic) ou encore Gemini (Google DeepMind) se sont imposés dans le quotidien de nombre
+		d'entre nous.
+	</p>
+
+	<p>
+		Pour rester dans le domaine du travail courant (c'est-à-dire sans parler de la recherche en
+		mathématique ou en biochimie où ils font des prouesses, par exemple), ces IA savent déjà lire,
+		analyser, synthétiser, traduire de longs documents, rédiger des textes clairs et structurés
+		(emails, rapports, résumés et même contenus créatifs) en adaptant le ton au public visé.
+		Certaines comprennent et traitent plusieurs formats : texte, images, audio ou vidéo. Elles
+		peuvent aussi expliquer, corriger et écrire du code informatique, et aider ainsi à développer
+		des logiciels plus vite. Enfin, elles servent de moteur à des « agents » capables d'enchaîner
+		des actions de manière autonome.
+	</p>
+
+	<h2>16&nbsp;% et jusqu'à 25&nbsp;% du travail déjà automatisable en France</h2>
+
+	<p>
+		Une étude menée conjointement par l'Observatoire des Emplois émergents ou Menacés (OEM) et la
+		Coface vient de montrer que, pour la France, 16&nbsp;% du contenu du travail serait déjà
+		automatisable. Il s'agit d'une moyenne. Ce taux dépasserait 25&nbsp;% dans le management,
+		l'administration, les métiers créatifs, le droit, la finance, l'ingénierie et l'informatique.
+		D'où un impact très sensible dans les grands centres urbains où ces métiers sont concentrés.
+	</p>
+
+	<p>
+		Précision importante : ces résultats valent pour la période actuelle, qui voit émerger les
+		premiers agents autonomes. Les auteurs ont également examiné des scénarios prospectifs, dans
+		lesquels l'IA acquiert de nouvelles capacités de planification et de coordination, qui
+		amèneraient à des taux d'automatisation très supérieurs.
+	</p>
+
+	<p>
+		Une telle rupture technologique est une hypothèse sérieuse. Les progrès de l'IA sont tellement
+		incroyables qu'ils sont impossibles à suivre pour le commun des mortels. Les spécialistes, en
+		revanche, suivent avec attention les performances des modèles sur de nombreux tests (appelés «
+		benchmarks »). Le laboratoire de recherche à but non lucratif EPOCH AI propose un index qui
+		permet d'établir une sorte de note moyenne. La croissance de cet index est extrêmement rapide :
+		les modèles deviennent chaque mois plus performants.
+	</p>
+
+	<h2>Désinvestir dans le travail pour investir dans l'IA</h2>
+
+	<p>
+		Notre économie connaît déjà les prémisses d'une transformation radicale. Rien d'étonnant à cela
+		puisque c'est le but principal que poursuivent les entreprises qui développent l'IA de pointe.
+		Leur objectif est de les amener à un niveau de compétence cognitive qui les rend capables de
+		remplacer voire de surpasser les humains dans un grand nombre de tâches. Elles continuent à
+		réaliser pour cela des investissements colossaux, en puissance de calcul et en centres de
+		données.
+	</p>
+
+	<p>
+		Pour les rentabiliser, il faudra que les géants de la tech puissent vendre massivement
+		l'utilisation de leurs modèles aux entreprises et aux administrations, si possible en les
+		rendant dépendantes de ces outils. Et pour que les entreprises et les administrations les
+		achètent, il faudra qu'elles y trouvent un intérêt : investir dans l'IA, mais désinvestir dans
+		le travail, et se rendre ainsi plus rentables ou plus efficaces.
+	</p>
+
+	<h2>Premiers signes</h2>
+
+	<p>
+		Les premiers licenciements ont commencé. Aux États-Unis, l'organisation à but non lucratif The
+		Alliance for secure AI a recensé près de 130&nbsp;000 annonces de suppressions d'emplois liées
+		au moins partiellement à l'IA depuis le 1<sup>er</sup> janvier 2025. Certaines professions souvent
+		exercées par des travailleurs indépendants – traducteurs, rédacteurs, développeurs web… – sont déjà
+		en grandes difficultés, les métiers créatifs sont également en première ligne face à la vague de
+		remplacement.
+	</p>
+
+	<p>
+		Enfin, de nombreuses analyses convergent pour s'inquiéter des difficultés croissantes des jeunes
+		diplômés à trouver leur premier emploi. C'est le cas, ironiquement, du patron de la startup
+		Anthropic, Dario Amodei, qui déclarait en mai 2025 au média états-unien Axios :
+	</p>
+
+	<blockquote>
+		<p>
+			« L'IA pourrait effacer la moitié de tous les premiers emplois de cols blancs et faire grimper
+			le chômage à 10-20&nbsp;% d'ici 1 à 5 ans. »
+		</p>
+	</blockquote>
+
+	<h2>Pas de pilote dans l'avion France</h2>
+
+	<p>
+		Avec une IA hors de contrôle, qu'est-ce qui pourrait mal se passer pour notre modèle économique
+		et social ?
+	</p>
+
+	<p>
+		Aucune limite n'arrête pour le moment les géants américains de la tech, ni réglementaire, ni
+		capitalistique, ni physique (énergie). Le développement des modèles d'IA de pointe se poursuit
+		donc, sans autre intention que de les rendre capables de faire aussi bien ou mieux que les
+		humains dans quasiment tous les domaines. Avec, à la clé, la promesse d'une croissance
+		économique à deux chiffres, nécessaire pour assurer la rentabilité future des capitaux investis,
+		mais dont le contenu reste pour le moins flou.
+	</p>
+
+	<h2>À tâtons dans le brouillard</h2>
+
+	<p>
+		Alors, cette croissance ? Il paraît clair que l'IA puisse être plus productive que les humains
+		dans des tâches de plus en plus nombreuses, et par là augmenter les bénéfices des entreprises.
+		On veut bien admettre qu'elle puisse rendre le travail plus intéressant pour les humains en les
+		« augmentant » (mais ça peut aussi être l'inverse). On voit aussi que, même si le processus peut
+		être complexe, le déploiement de l'IA dans les entreprises semble déjà inévitable dans de
+		nombreux domaines : celles qui ne l'utiliseront pas ne pourront pas résister à la concurrence.
+		On verra même se créer des entreprises entièrement pilotées par l'IA, sans employé ou presque.
+	</p>
+
+	<p>
+		Au-delà de ces généralités, personne ne sait dire à quoi l'économie de demain ressemblera, sinon
+		qu'il y aura moins d'humains occupés à des tâches purement intellectuelles ou, à terme, purement
+		manuelles (le développement de la robotique étant également boosté par les progrès de
+		l'intelligence artificielle). L'avenir se laisse d'autant moins appréhender que le moteur de
+		cette mutation est une technologie littéralement incontrôlée, dont les « progrès » vont de pair
+		avec une insécurité croissante.
+	</p>
+
+	<p>
+		Faut-il croire les optimistes pour qui la révolution de l'IA, comme les révolutions
+		industrielles avant elle, va supprimer des emplois pour mieux en créer d'autres et finalement
+		déboucher sur une plus grande prospérité (théorie de la destruction créatrice) ? Non car cette
+		révolution-là est beaucoup plus rapide que les précédentes : tout va beaucoup trop vite, sans
+		stratégie industrielle claire, sans amortisseur social, sans réorientation rapide de notre
+		système éducatif.
+	</p>
+
+	<h2>Le scénario le plus probable : un chômage massif et brutal</h2>
+
+	<p>
+		Dans un premier temps, ce seront surtout les jeunes qui ne trouveront plus d'emploi. Les tâches
+		habituellement confiées à des juniors seront de plus en plus effectuées par l'IA, laquelle sera
+		mise en place et contrôlée par des personnes expérimentées. Outre les préjudices causés aux
+		individus de cette génération, les conséquences systémiques sont graves : les diplômes se
+		démonétisent puisqu'ils ne procurent plus d'emploi. Sans emploi, l'acquisition d'expérience
+		devient impossible, de même que la transmission des plus âgés vers les plus jeunes.
+	</p>
+
+	<p>
+		À la différence de crises précédentes (désindustrialisation, automatisation, informatique,
+		mondialisation) qui ont touché progressivement des travailleurs peu qualifiés ou très
+		spécialisés, les premières tâches automatisables par l'IA sont celles effectuées par des
+		professions intellectuelles aux salaires relativement élevés par rapport à la moyenne. C'est
+		donc un volume important de recettes de cotisations sociales qui est menacé de volatilisation à
+		court terme. L'évolution dépend ensuite des progrès de l'IA, susceptibles de monter à nouveau en
+		flèche et entraînant une nouvelle vague d'automatisation.
+	</p>
+
+	<h2>Notre modèle socio-économique en jeu</h2>
+
+	<p>
+		Il est impensable, dans une économie sans ligne directrice claire, que les personnes déclassées
+		par l'IA puissent acquérir en quelques mois de nouvelles compétences non remplaçables par l'IA
+		(si elles les acquièrent jamais) et trouver un nouvel emploi.
+	</p>
+
+	<p>
+		Ce qui est certain en revanche, c'est qu'une fonte rapide et irréversible des revenus du travail
+		remettrait en cause notre modèle de société. Schématiquement, moins de travail, c'est moins de
+		cotisations sociales donc moins d'argent pour assurer le versement de prestations (assurance
+		chômage, maladie, retraite…). C'est moins de revenus pour vivre, pour consommer et pour faire
+		tourner l'économie des biens et services de consommation.
+	</p>
+
+	<p>
+		Même Sam Altman, le PDG d'OpenAI, s'en inquiète. Dans une note publiée en avril 2026, il enjoint
+		aux pouvoirs publics de considérer des solutions telles qu'un revenu de remplacement, la
+		création d'un fonds alimenté par les entreprises de la tech, ou d'autres.
+	</p>
+
+	<h2>Dépendance inacceptable</h2>
+
+	<p>
+		Méditons sur cette perspective : voulons-nous que nos vies dépendent des revenus d'entreprises
+		hyper-puissantes, dont les produits ont par ailleurs des effets délétères sur nos démocraties,
+		nos cerveaux, notre santé mentale, nos ressources naturelles ? Ou préférons-nous garder le
+		contrôle de notre économie et de notre modèle social ?
+	</p>
+
+	<p>
+		Mais au fond, quel contrôle nous reste-t-il, et comment le conserver ? Dans un monde où la
+		croissance économique dépendra de moins en moins du travail et de plus en plus du capital
+		investi dans l'intelligence artificielle et ses infrastructures, ce sont les revenus de ce
+		capital qui devront être redistribués. Qui décidera si ce capital sera investi dans la santé
+		pour tous et la transition écologique ou dans la guerre et la colonisation de la planète Mars ?
+	</p>
+
+	<p>
+		Derrière la question de l'emploi, c'est véritablement notre monde qui est en jeu. Il faut bien
+		comprendre que les progrès de l'intelligence artificielle générale accélèrent de manière
+		incontrôlée la destruction de notre modèle socio-économique, pour le remplacer par une
+		dépendance gravissime à la superpuissance de la Silicon Valley, des États-Unis et de la Chine.
+	</p>
+
+	<p>
+		Cette perte de souveraineté n'est pas acceptable : nous demandons un moratoire international sur
+		l'entraînement des modèles d'intelligence artificielle de pointe, le temps nécessaire pour que
+		les conditions de sécurité et de contrôle démocratique soient réunies.
+	</p>
+
+	<div class="cta-box">
+		<p class="cta-text">Vous aussi, agissez pour un développement de l'IA sûr et démocratique.</p>
+		<a href="/{data.lang}/emploi-ia" class="cta-btn">Je participe à la campagne</a>
+	</div>
+
+	<nav class="back-nav">
+		<a href="/{data.lang}/emploi-ia">&larr; Retour à la campagne Emploi et IA</a>
+	</nav>
+</article>
+
+<style>
+	article {
+		max-inline-size: 50rem;
+		margin-inline: auto;
+		margin-top: 2rem;
+		padding: 0 1rem;
+	}
+
+	.intro {
+		font-size: 1.15rem;
+		font-weight: 500;
+		color: var(--brand-subtle, #c96900);
+		border-left: 4px solid var(--brand, #ff9416);
+		background: var(--brand-light, #fff5e8);
+		padding: 1rem 1.25rem;
+		margin: 1.5rem 0;
+	}
+
+	.cta-box {
+		margin: 3rem 0 2rem;
+		padding: 2rem;
+		background: var(--brand-light, #fff5e8);
+		border-left: 4px solid var(--brand, #ff9416);
+		border-radius: 0 12px 12px 0;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 1rem;
+	}
+
+	.cta-text {
+		font-weight: 600;
+		color: var(--brand-subtle, #c96900);
+		margin: 0;
+	}
+
+	.cta-btn {
+		display: inline-block;
+		background: var(--brand, #ff9416);
+		color: white;
+		text-decoration: none;
+		padding: 0.75rem 1.5rem;
+		border-radius: 6px;
+		font-weight: 600;
+		transition: background 0.2s;
+	}
+
+	.cta-btn:hover {
+		background: var(--btn-hover-bg, #ffa945);
+		color: white;
+	}
+
+	.back-nav {
+		margin-top: 3rem;
+		padding-top: 1.5rem;
+		border-top: 1px solid var(--border, #e5e7eb);
+	}
+
+	.back-nav a {
+		color: var(--text-secondary, #676e7a);
+		text-decoration: none;
+		font-size: 0.9375rem;
+		transition: color 0.2s;
+	}
+
+	.back-nav a:hover {
+		color: var(--brand, #ff9416);
+	}
+</style>

--- a/src/routes/[lang=lang]/emploi-ia/remplacer-humain/+page.svelte
+++ b/src/routes/[lang=lang]/emploi-ia/remplacer-humain/+page.svelte
@@ -9,12 +9,24 @@
 	<title>Remplacer l'humain, tel est l'objectif | PauseAI France</title>
 	<meta
 		name="description"
-		content="Derrière l'aventure scientifique fascinante de l'intelligence artificielle, c'est bien la prise de contrôle de nos vies, à commencer par notre travail, qui est en jeu."
+		content="En quelques années, l'IA est devenue capable de remplacer les humains dans des tâches de plus en plus nombreuses — 16 % du travail déjà automatisable en France."
 	/>
 	<meta name="robots" content="index, follow" />
 </svelte:head>
 
 <article>
+	<nav class="breadcrumb">
+		<a href="/{data.lang}/emploi-ia">← Campagne Emploi &amp; IA</a>
+	</nav>
+
+	<div class="article-meta">
+		<span class="meta-tag">Analyse</span>
+		<span class="meta-sep">·</span>
+		<span class="meta-series">Article 1/2</span>
+		<span class="meta-sep">·</span>
+		<span class="meta-reading">4 min de lecture</span>
+	</div>
+
 	<hgroup>
 		<UnderlinedTitle as="h1">Remplacer l'humain, tel est l'objectif</UnderlinedTitle>
 	</hgroup>
@@ -109,134 +121,20 @@
 			« L'IA pourrait effacer la moitié de tous les premiers emplois de cols blancs et faire grimper
 			le chômage à 10-20&nbsp;% d'ici 1 à 5 ans. »
 		</p>
+		<footer>— Dario Amodei, PDG d'Anthropic, mai 2025</footer>
 	</blockquote>
 
-	<h2>Pas de pilote dans l'avion France</h2>
-
-	<p>
-		Avec une IA hors de contrôle, qu'est-ce qui pourrait mal se passer pour notre modèle économique
-		et social ?
-	</p>
-
-	<p>
-		Aucune limite n'arrête pour le moment les géants américains de la tech, ni réglementaire, ni
-		capitalistique, ni physique (énergie). Le développement des modèles d'IA de pointe se poursuit
-		donc, sans autre intention que de les rendre capables de faire aussi bien ou mieux que les
-		humains dans quasiment tous les domaines. Avec, à la clé, la promesse d'une croissance
-		économique à deux chiffres, nécessaire pour assurer la rentabilité future des capitaux investis,
-		mais dont le contenu reste pour le moins flou.
-	</p>
-
-	<h2>À tâtons dans le brouillard</h2>
-
-	<p>
-		Alors, cette croissance ? Il paraît clair que l'IA puisse être plus productive que les humains
-		dans des tâches de plus en plus nombreuses, et par là augmenter les bénéfices des entreprises.
-		On veut bien admettre qu'elle puisse rendre le travail plus intéressant pour les humains en les
-		« augmentant » (mais ça peut aussi être l'inverse). On voit aussi que, même si le processus peut
-		être complexe, le déploiement de l'IA dans les entreprises semble déjà inévitable dans de
-		nombreux domaines : celles qui ne l'utiliseront pas ne pourront pas résister à la concurrence.
-		On verra même se créer des entreprises entièrement pilotées par l'IA, sans employé ou presque.
-	</p>
-
-	<p>
-		Au-delà de ces généralités, personne ne sait dire à quoi l'économie de demain ressemblera, sinon
-		qu'il y aura moins d'humains occupés à des tâches purement intellectuelles ou, à terme, purement
-		manuelles (le développement de la robotique étant également boosté par les progrès de
-		l'intelligence artificielle). L'avenir se laisse d'autant moins appréhender que le moteur de
-		cette mutation est une technologie littéralement incontrôlée, dont les « progrès » vont de pair
-		avec une insécurité croissante.
-	</p>
-
-	<p>
-		Faut-il croire les optimistes pour qui la révolution de l'IA, comme les révolutions
-		industrielles avant elle, va supprimer des emplois pour mieux en créer d'autres et finalement
-		déboucher sur une plus grande prospérité (théorie de la destruction créatrice) ? Non car cette
-		révolution-là est beaucoup plus rapide que les précédentes : tout va beaucoup trop vite, sans
-		stratégie industrielle claire, sans amortisseur social, sans réorientation rapide de notre
-		système éducatif.
-	</p>
-
-	<h2>Le scénario le plus probable : un chômage massif et brutal</h2>
-
-	<p>
-		Dans un premier temps, ce seront surtout les jeunes qui ne trouveront plus d'emploi. Les tâches
-		habituellement confiées à des juniors seront de plus en plus effectuées par l'IA, laquelle sera
-		mise en place et contrôlée par des personnes expérimentées. Outre les préjudices causés aux
-		individus de cette génération, les conséquences systémiques sont graves : les diplômes se
-		démonétisent puisqu'ils ne procurent plus d'emploi. Sans emploi, l'acquisition d'expérience
-		devient impossible, de même que la transmission des plus âgés vers les plus jeunes.
-	</p>
-
-	<p>
-		À la différence de crises précédentes (désindustrialisation, automatisation, informatique,
-		mondialisation) qui ont touché progressivement des travailleurs peu qualifiés ou très
-		spécialisés, les premières tâches automatisables par l'IA sont celles effectuées par des
-		professions intellectuelles aux salaires relativement élevés par rapport à la moyenne. C'est
-		donc un volume important de recettes de cotisations sociales qui est menacé de volatilisation à
-		court terme. L'évolution dépend ensuite des progrès de l'IA, susceptibles de monter à nouveau en
-		flèche et entraînant une nouvelle vague d'automatisation.
-	</p>
-
-	<h2>Notre modèle socio-économique en jeu</h2>
-
-	<p>
-		Il est impensable, dans une économie sans ligne directrice claire, que les personnes déclassées
-		par l'IA puissent acquérir en quelques mois de nouvelles compétences non remplaçables par l'IA
-		(si elles les acquièrent jamais) et trouver un nouvel emploi.
-	</p>
-
-	<p>
-		Ce qui est certain en revanche, c'est qu'une fonte rapide et irréversible des revenus du travail
-		remettrait en cause notre modèle de société. Schématiquement, moins de travail, c'est moins de
-		cotisations sociales donc moins d'argent pour assurer le versement de prestations (assurance
-		chômage, maladie, retraite…). C'est moins de revenus pour vivre, pour consommer et pour faire
-		tourner l'économie des biens et services de consommation.
-	</p>
-
-	<p>
-		Même Sam Altman, le PDG d'OpenAI, s'en inquiète. Dans une note publiée en avril 2026, il enjoint
-		aux pouvoirs publics de considérer des solutions telles qu'un revenu de remplacement, la
-		création d'un fonds alimenté par les entreprises de la tech, ou d'autres.
-	</p>
-
-	<h2>Dépendance inacceptable</h2>
-
-	<p>
-		Méditons sur cette perspective : voulons-nous que nos vies dépendent des revenus d'entreprises
-		hyper-puissantes, dont les produits ont par ailleurs des effets délétères sur nos démocraties,
-		nos cerveaux, notre santé mentale, nos ressources naturelles ? Ou préférons-nous garder le
-		contrôle de notre économie et de notre modèle social ?
-	</p>
-
-	<p>
-		Mais au fond, quel contrôle nous reste-t-il, et comment le conserver ? Dans un monde où la
-		croissance économique dépendra de moins en moins du travail et de plus en plus du capital
-		investi dans l'intelligence artificielle et ses infrastructures, ce sont les revenus de ce
-		capital qui devront être redistribués. Qui décidera si ce capital sera investi dans la santé
-		pour tous et la transition écologique ou dans la guerre et la colonisation de la planète Mars ?
-	</p>
-
-	<p>
-		Derrière la question de l'emploi, c'est véritablement notre monde qui est en jeu. Il faut bien
-		comprendre que les progrès de l'intelligence artificielle générale accélèrent de manière
-		incontrôlée la destruction de notre modèle socio-économique, pour le remplacer par une
-		dépendance gravissime à la superpuissance de la Silicon Valley, des États-Unis et de la Chine.
-	</p>
-
-	<p>
-		Cette perte de souveraineté n'est pas acceptable : nous demandons un moratoire international sur
-		l'entraînement des modèles d'intelligence artificielle de pointe, le temps nécessaire pour que
-		les conditions de sécurité et de contrôle démocratique soient réunies.
-	</p>
-
-	<div class="cta-box">
-		<p class="cta-text">Vous aussi, agissez pour un développement de l'IA sûr et démocratique.</p>
-		<a href="/{data.lang}/emploi-ia" class="cta-btn">Je participe à la campagne</a>
-	</div>
+	<a href="/{data.lang}/emploi-ia/pas-de-pilote" class="next-article">
+		<span class="next-label">Article suivant →</span>
+		<strong class="next-title">Pas de pilote dans l'avion France</strong>
+		<span class="next-desc"
+			>Chômage massif, modèle social menacé, dépendance à la Silicon Valley : ce qui nous attend si
+			nous ne réagissons pas.</span
+		>
+	</a>
 
 	<nav class="back-nav">
-		<a href="/{data.lang}/emploi-ia">&larr; Retour à la campagne Emploi et IA</a>
+		<a href="/{data.lang}/emploi-ia">← Retour à la campagne Emploi &amp; IA</a>
 	</nav>
 </article>
 
@@ -248,6 +146,56 @@
 		padding: 0 1rem;
 	}
 
+	.breadcrumb {
+		margin-bottom: 1.5rem;
+	}
+
+	.breadcrumb a {
+		font-size: 0.875rem;
+		color: var(--text-secondary, #676e7a);
+		text-decoration: none;
+		transition: color 0.2s;
+	}
+
+	.breadcrumb a:hover {
+		color: var(--brand, #ff9416);
+	}
+
+	.article-meta {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		margin-bottom: 1.25rem;
+		flex-wrap: wrap;
+	}
+
+	.meta-tag {
+		font-size: 0.7rem;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--brand-subtle, #c96900);
+		background: var(--brand-light, #fff5e8);
+		padding: 0.2rem 0.55rem;
+		border-radius: 4px;
+	}
+
+	.meta-sep {
+		color: var(--border, #d1d5db);
+		font-size: 0.8rem;
+	}
+
+	.meta-series {
+		font-size: 0.8125rem;
+		font-weight: 600;
+		color: var(--text-secondary, #555);
+	}
+
+	.meta-reading {
+		font-size: 0.8125rem;
+		color: var(--text-secondary, #888);
+	}
+
 	.intro {
 		font-size: 1.15rem;
 		font-weight: 500;
@@ -255,47 +203,85 @@
 		border-left: 4px solid var(--brand, #ff9416);
 		background: var(--brand-light, #fff5e8);
 		padding: 1rem 1.25rem;
-		margin: 1.5rem 0;
+		margin: 1.5rem 0 2rem;
 	}
 
-	.cta-box {
-		margin: 3rem 0 2rem;
-		padding: 2rem;
-		background: var(--brand-light, #fff5e8);
+	h2 {
+		margin-top: 2.5rem;
+	}
+
+	blockquote {
 		border-left: 4px solid var(--brand, #ff9416);
-		border-radius: 0 12px 12px 0;
+		margin: 2rem 0;
+		padding: 1.25rem 1.5rem;
+		background: var(--bg-subtle, #f7f7f5);
+		border-radius: 0 8px 8px 0;
+	}
+
+	:global([data-theme='dark']) blockquote {
+		background: rgba(255, 255, 255, 0.04);
+	}
+
+	blockquote p {
+		margin: 0 0 0.5rem;
+		font-style: italic;
+		font-size: 1.05rem;
+		color: var(--brand-subtle, #c96900);
+		font-weight: 500;
+	}
+
+	blockquote footer {
+		font-size: 0.8rem;
+		color: var(--text-secondary, #888);
+		font-style: normal;
+	}
+
+	.next-article {
 		display: flex;
 		flex-direction: column;
-		align-items: flex-start;
-		gap: 1rem;
-	}
-
-	.cta-text {
-		font-weight: 600;
-		color: var(--brand-subtle, #c96900);
-		margin: 0;
-	}
-
-	.cta-btn {
-		display: inline-block;
-		background: var(--brand, #ff9416);
-		color: white;
+		gap: 0.4rem;
+		margin: 3rem 0 1.5rem;
+		padding: 1.5rem;
+		border: 1px solid var(--border, #e5e7eb);
+		border-radius: 10px;
 		text-decoration: none;
-		padding: 0.75rem 1.5rem;
-		border-radius: 6px;
-		font-weight: 600;
-		transition: background 0.2s;
+		color: inherit;
+		transition:
+			border-color 0.2s,
+			box-shadow 0.2s;
 	}
 
-	.cta-btn:hover {
-		background: var(--btn-hover-bg, #ffa945);
-		color: white;
+	.next-article:hover {
+		border-color: var(--brand, #ff9416);
+		box-shadow: 0 2px 12px rgba(255, 148, 22, 0.12);
+	}
+
+	.next-label {
+		font-size: 0.75rem;
+		font-weight: 700;
+		letter-spacing: 0.07em;
+		text-transform: uppercase;
+		color: var(--brand-subtle, #c96900);
+	}
+
+	.next-title {
+		font-size: 1rem;
+		font-weight: 700;
+		color: var(--text, #111);
+		display: block;
+	}
+
+	.next-desc {
+		font-size: 0.875rem;
+		color: var(--text-secondary, #676e7a);
+		line-height: 1.5;
 	}
 
 	.back-nav {
-		margin-top: 3rem;
+		margin-top: 2rem;
 		padding-top: 1.5rem;
 		border-top: 1px solid var(--border, #e5e7eb);
+		margin-bottom: 3rem;
 	}
 
 	.back-nav a {

--- a/src/routes/[lang=lang]/emploi-ia/remplacer-humain/+page.ts
+++ b/src/routes/[lang=lang]/emploi-ia/remplacer-humain/+page.ts
@@ -1,6 +1,8 @@
-import type { PageLoad } from './$types'
+import type { PageLoad, EntryGenerator } from './$types'
 
 export const prerender = true
+
+export const entries: EntryGenerator = () => [{ lang: 'fr' }, { lang: 'en' }]
 
 export const load: PageLoad = ({ params }) => {
 	return { lang: params.lang }

--- a/src/routes/[lang=lang]/emploi-ia/remplacer-humain/+page.ts
+++ b/src/routes/[lang=lang]/emploi-ia/remplacer-humain/+page.ts
@@ -1,0 +1,7 @@
+import type { PageLoad } from './$types'
+
+export const prerender = true
+
+export const load: PageLoad = ({ params }) => {
+	return { lang: params.lang }
+}

--- a/src/routes/emploi-ia/pas-de-pilote/+page.svelte
+++ b/src/routes/emploi-ia/pas-de-pilote/+page.svelte
@@ -1,0 +1,293 @@
+<script lang="ts">
+	import UnderlinedTitle from '$components/UnderlinedTitle.svelte'
+</script>
+
+<svelte:head>
+	<title>Pas de pilote dans l'avion France | PauseAI France</title>
+	<meta
+		name="description"
+		content="Chômage massif des jeunes, modèle social fragilisé, dépendance à la Silicon Valley : à quoi ressemblera notre monde si nous ne réagissons pas à la montée de l'IA."
+	/>
+	<meta name="robots" content="index, follow" />
+</svelte:head>
+
+<article>
+	<nav class="breadcrumb">
+		<a href="/emploi-ia">← Campagne Emploi &amp; IA</a>
+	</nav>
+
+	<div class="article-meta">
+		<span class="meta-tag">Analyse</span>
+		<span class="meta-sep">·</span>
+		<span class="meta-series">Article 2/2</span>
+		<span class="meta-sep">·</span>
+		<span class="meta-reading">5 min de lecture</span>
+	</div>
+
+	<hgroup>
+		<UnderlinedTitle as="h1">Pas de pilote dans l'avion France</UnderlinedTitle>
+	</hgroup>
+
+	<p class="intro">
+		Avec une IA hors de contrôle, qu'est-ce qui pourrait mal se passer pour notre modèle économique
+		et social ?
+	</p>
+
+	<p>
+		Aucune limite n'arrête pour le moment les géants américains de la tech, ni réglementaire, ni
+		capitalistique, ni physique (énergie). Le développement des modèles d'IA de pointe se poursuit
+		donc, sans autre intention que de les rendre capables de faire aussi bien ou mieux que les
+		humains dans quasiment tous les domaines. Avec, à la clé, la promesse d'une croissance
+		économique à deux chiffres, nécessaire pour assurer la rentabilité future des capitaux investis,
+		mais dont le contenu reste pour le moins flou.
+	</p>
+
+	<h2>À tâtons dans le brouillard</h2>
+
+	<p>
+		Alors, cette croissance ? Il paraît clair que l'IA puisse être plus productive que les humains
+		dans des tâches de plus en plus nombreuses, et par là augmenter les bénéfices des entreprises.
+		On veut bien admettre qu'elle puisse rendre le travail plus intéressant pour les humains en les
+		« augmentant » (mais ça peut aussi être l'inverse). On voit aussi que, même si le processus peut
+		être complexe, le déploiement de l'IA dans les entreprises semble déjà inévitable dans de
+		nombreux domaines : celles qui ne l'utiliseront pas ne pourront pas résister à la concurrence.
+		On verra même se créer des entreprises entièrement pilotées par l'IA, sans employé ou presque.
+	</p>
+
+	<p>
+		Au-delà de ces généralités, personne ne sait dire à quoi l'économie de demain ressemblera, sinon
+		qu'il y aura moins d'humains occupés à des tâches purement intellectuelles ou, à terme, purement
+		manuelles (le développement de la robotique étant également boosté par les progrès de
+		l'intelligence artificielle). L'avenir se laisse d'autant moins appréhender que le moteur de
+		cette mutation est une technologie littéralement incontrôlée, dont les « progrès » vont de pair
+		avec une insécurité croissante.
+	</p>
+
+	<p>
+		Faut-il croire les optimistes pour qui la révolution de l'IA, comme les révolutions
+		industrielles avant elle, va supprimer des emplois pour mieux en créer d'autres et finalement
+		déboucher sur une plus grande prospérité (théorie de la destruction créatrice) ? Non car cette
+		révolution-là est beaucoup plus rapide que les précédentes : tout va beaucoup trop vite, sans
+		stratégie industrielle claire, sans amortisseur social, sans réorientation rapide de notre
+		système éducatif.
+	</p>
+
+	<h2>Le scénario le plus probable : un chômage massif et brutal</h2>
+
+	<p>
+		Dans un premier temps, ce seront surtout les jeunes qui ne trouveront plus d'emploi. Les tâches
+		habituellement confiées à des juniors seront de plus en plus effectuées par l'IA, laquelle sera
+		mise en place et contrôlée par des personnes expérimentées. Outre les préjudices causés aux
+		individus de cette génération, les conséquences systémiques sont graves : les diplômes se
+		démonétisent puisqu'ils ne procurent plus d'emploi. Sans emploi, l'acquisition d'expérience
+		devient impossible, de même que la transmission des plus âgés vers les plus jeunes.
+	</p>
+
+	<p>
+		À la différence de crises précédentes (désindustrialisation, automatisation, informatique,
+		mondialisation) qui ont touché progressivement des travailleurs peu qualifiés ou très
+		spécialisés, les premières tâches automatisables par l'IA sont celles effectuées par des
+		professions intellectuelles aux salaires relativement élevés par rapport à la moyenne. C'est
+		donc un volume important de recettes de cotisations sociales qui est menacé de volatilisation à
+		court terme. L'évolution dépend ensuite des progrès de l'IA, susceptibles de monter à nouveau en
+		flèche et entraînant une nouvelle vague d'automatisation.
+	</p>
+
+	<h2>Notre modèle socio-économique en jeu</h2>
+
+	<p>
+		Il est impensable, dans une économie sans ligne directrice claire, que les personnes déclassées
+		par l'IA puissent acquérir en quelques mois de nouvelles compétences non remplaçables par l'IA
+		(si elles les acquièrent jamais) et trouver un nouvel emploi.
+	</p>
+
+	<p>
+		Ce qui est certain en revanche, c'est qu'une fonte rapide et irréversible des revenus du travail
+		remettrait en cause notre modèle de société. Schématiquement, moins de travail, c'est moins de
+		cotisations sociales donc moins d'argent pour assurer le versement de prestations (assurance
+		chômage, maladie, retraite…). C'est moins de revenus pour vivre, pour consommer et pour faire
+		tourner l'économie des biens et services de consommation.
+	</p>
+
+	<p>
+		Même Sam Altman, le PDG d'OpenAI, s'en inquiète. Dans une note publiée en avril 2026, il enjoint
+		aux pouvoirs publics de considérer des solutions telles qu'un revenu de remplacement, la
+		création d'un fonds alimenté par les entreprises de la tech, ou d'autres.
+	</p>
+
+	<h2>Dépendance inacceptable</h2>
+
+	<p>
+		Méditons sur cette perspective : voulons-nous que nos vies dépendent des revenus d'entreprises
+		hyper-puissantes, dont les produits ont par ailleurs des effets délétères sur nos démocraties,
+		nos cerveaux, notre santé mentale, nos ressources naturelles ? Ou préférons-nous garder le
+		contrôle de notre économie et de notre modèle social ?
+	</p>
+
+	<p>
+		Mais au fond, quel contrôle nous reste-t-il, et comment le conserver ? Dans un monde où la
+		croissance économique dépendra de moins en moins du travail et de plus en plus du capital
+		investi dans l'intelligence artificielle et ses infrastructures, ce sont les revenus de ce
+		capital qui devront être redistribués. Qui décidera si ce capital sera investi dans la santé
+		pour tous et la transition écologique ou dans la guerre et la colonisation de la planète Mars ?
+	</p>
+
+	<p>
+		Derrière la question de l'emploi, c'est véritablement notre monde qui est en jeu. Il faut bien
+		comprendre que les progrès de l'intelligence artificielle générale accélèrent de manière
+		incontrôlée la destruction de notre modèle socio-économique, pour le remplacer par une
+		dépendance gravissime à la superpuissance de la Silicon Valley, des États-Unis et de la Chine.
+	</p>
+
+	<p>
+		Cette perte de souveraineté n'est pas acceptable : nous demandons un moratoire international sur
+		l'entraînement des modèles d'intelligence artificielle de pointe, le temps nécessaire pour que
+		les conditions de sécurité et de contrôle démocratique soient réunies.
+	</p>
+
+	<div class="cta-box">
+		<p class="cta-text">Vous aussi, agissez pour un développement de l'IA sûr et démocratique.</p>
+		<a href="/emploi-ia" class="cta-btn">Je participe à la campagne</a>
+	</div>
+
+	<nav class="article-nav">
+		<a href="/emploi-ia/remplacer-humain" class="nav-prev"
+			>← Remplacer l'humain, tel est l'objectif</a
+		>
+		<a href="/emploi-ia" class="nav-back">Campagne Emploi &amp; IA</a>
+	</nav>
+</article>
+
+<style>
+	article {
+		max-inline-size: 50rem;
+		margin-inline: auto;
+		margin-top: 2rem;
+		padding: 0 1rem;
+	}
+
+	.breadcrumb {
+		margin-bottom: 1.5rem;
+	}
+
+	.breadcrumb a {
+		font-size: 0.875rem;
+		color: var(--text-secondary, #676e7a);
+		text-decoration: none;
+		transition: color 0.2s;
+	}
+
+	.breadcrumb a:hover {
+		color: var(--brand, #ff9416);
+	}
+
+	.article-meta {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		margin-bottom: 1.25rem;
+		flex-wrap: wrap;
+	}
+
+	.meta-tag {
+		font-size: 0.7rem;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--brand-subtle, #c96900);
+		background: var(--brand-light, #fff5e8);
+		padding: 0.2rem 0.55rem;
+		border-radius: 4px;
+	}
+
+	.meta-sep {
+		color: var(--border, #d1d5db);
+		font-size: 0.8rem;
+	}
+
+	.meta-series {
+		font-size: 0.8125rem;
+		font-weight: 600;
+		color: var(--text-secondary, #555);
+	}
+
+	.meta-reading {
+		font-size: 0.8125rem;
+		color: var(--text-secondary, #888);
+	}
+
+	.intro {
+		font-size: 1.15rem;
+		font-weight: 500;
+		color: var(--brand-subtle, #c96900);
+		border-left: 4px solid var(--brand, #ff9416);
+		background: var(--brand-light, #fff5e8);
+		padding: 1rem 1.25rem;
+		margin: 1.5rem 0 2rem;
+	}
+
+	h2 {
+		margin-top: 2.5rem;
+	}
+
+	.cta-box {
+		margin: 3rem 0 2rem;
+		padding: 2rem;
+		background: var(--brand-light, #fff5e8);
+		border-left: 4px solid var(--brand, #ff9416);
+		border-radius: 0 12px 12px 0;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 1rem;
+	}
+
+	.cta-text {
+		font-weight: 600;
+		color: var(--brand-subtle, #c96900);
+		margin: 0;
+	}
+
+	.cta-btn {
+		display: inline-block;
+		background: var(--brand, #ff9416);
+		color: white;
+		text-decoration: none;
+		padding: 0.75rem 1.5rem;
+		border-radius: 6px;
+		font-weight: 600;
+		transition: background 0.2s;
+	}
+
+	.cta-btn:hover {
+		background: var(--btn-hover-bg, #ffa945);
+		color: white;
+	}
+
+	.article-nav {
+		margin-top: 2rem;
+		padding-top: 1.5rem;
+		border-top: 1px solid var(--border, #e5e7eb);
+		margin-bottom: 3rem;
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		flex-wrap: wrap;
+		gap: 0.75rem;
+	}
+
+	.article-nav a {
+		color: var(--text-secondary, #676e7a);
+		text-decoration: none;
+		font-size: 0.9375rem;
+		transition: color 0.2s;
+	}
+
+	.article-nav a:hover {
+		color: var(--brand, #ff9416);
+	}
+
+	.nav-back {
+		font-size: 0.875rem !important;
+	}
+</style>

--- a/src/routes/emploi-ia/remplacer-humain/+page.svelte
+++ b/src/routes/emploi-ia/remplacer-humain/+page.svelte
@@ -1,0 +1,308 @@
+<script lang="ts">
+	import UnderlinedTitle from '$components/UnderlinedTitle.svelte'
+</script>
+
+<svelte:head>
+	<title>Remplacer l'humain, tel est l'objectif | PauseAI France</title>
+	<meta
+		name="description"
+		content="Derrière l'aventure scientifique fascinante de l'intelligence artificielle, c'est bien la prise de contrôle de nos vies, à commencer par notre travail, qui est en jeu."
+	/>
+	<meta name="robots" content="index, follow" />
+</svelte:head>
+
+<article>
+	<hgroup>
+		<UnderlinedTitle as="h1">Remplacer l'humain, tel est l'objectif</UnderlinedTitle>
+	</hgroup>
+
+	<p class="intro">
+		Derrière l'aventure scientifique fascinante de l'intelligence artificielle, c'est bien la prise
+		de contrôle de nos vies, à commencer par notre travail, qui est en jeu.
+	</p>
+
+	<p>
+		En l'espace de quelques années, les modèles d'intelligence artificielle de pointe tels que GPT
+		(développé par OpenAI, plus connu sous le nom de son agent conversationnel ChatGPT), Claude
+		(Anthropic) ou encore Gemini (Google DeepMind) se sont imposés dans le quotidien de nombre
+		d'entre nous.
+	</p>
+
+	<p>
+		Pour rester dans le domaine du travail courant (c'est-à-dire sans parler de la recherche en
+		mathématique ou en biochimie où ils font des prouesses, par exemple), ces IA savent déjà lire,
+		analyser, synthétiser, traduire de longs documents, rédiger des textes clairs et structurés
+		(emails, rapports, résumés et même contenus créatifs) en adaptant le ton au public visé.
+		Certaines comprennent et traitent plusieurs formats : texte, images, audio ou vidéo. Elles
+		peuvent aussi expliquer, corriger et écrire du code informatique, et aider ainsi à développer
+		des logiciels plus vite. Enfin, elles servent de moteur à des « agents » capables d'enchaîner
+		des actions de manière autonome.
+	</p>
+
+	<h2>16&nbsp;% et jusqu'à 25&nbsp;% du travail déjà automatisable en France</h2>
+
+	<p>
+		Une étude menée conjointement par l'Observatoire des Emplois émergents ou Menacés (OEM) et la
+		Coface vient de montrer que, pour la France, 16&nbsp;% du contenu du travail serait déjà
+		automatisable. Il s'agit d'une moyenne. Ce taux dépasserait 25&nbsp;% dans le management,
+		l'administration, les métiers créatifs, le droit, la finance, l'ingénierie et l'informatique.
+		D'où un impact très sensible dans les grands centres urbains où ces métiers sont concentrés.
+	</p>
+
+	<p>
+		Précision importante : ces résultats valent pour la période actuelle, qui voit émerger les
+		premiers agents autonomes. Les auteurs ont également examiné des scénarios prospectifs, dans
+		lesquels l'IA acquiert de nouvelles capacités de planification et de coordination, qui
+		amèneraient à des taux d'automatisation très supérieurs.
+	</p>
+
+	<p>
+		Une telle rupture technologique est une hypothèse sérieuse. Les progrès de l'IA sont tellement
+		incroyables qu'ils sont impossibles à suivre pour le commun des mortels. Les spécialistes, en
+		revanche, suivent avec attention les performances des modèles sur de nombreux tests (appelés «
+		benchmarks »). Le laboratoire de recherche à but non lucratif EPOCH AI propose un index qui
+		permet d'établir une sorte de note moyenne. La croissance de cet index est extrêmement rapide :
+		les modèles deviennent chaque mois plus performants.
+	</p>
+
+	<h2>Désinvestir dans le travail pour investir dans l'IA</h2>
+
+	<p>
+		Notre économie connaît déjà les prémisses d'une transformation radicale. Rien d'étonnant à cela
+		puisque c'est le but principal que poursuivent les entreprises qui développent l'IA de pointe.
+		Leur objectif est de les amener à un niveau de compétence cognitive qui les rend capables de
+		remplacer voire de surpasser les humains dans un grand nombre de tâches. Elles continuent à
+		réaliser pour cela des investissements colossaux, en puissance de calcul et en centres de
+		données.
+	</p>
+
+	<p>
+		Pour les rentabiliser, il faudra que les géants de la tech puissent vendre massivement
+		l'utilisation de leurs modèles aux entreprises et aux administrations, si possible en les
+		rendant dépendantes de ces outils. Et pour que les entreprises et les administrations les
+		achètent, il faudra qu'elles y trouvent un intérêt : investir dans l'IA, mais désinvestir dans
+		le travail, et se rendre ainsi plus rentables ou plus efficaces.
+	</p>
+
+	<h2>Premiers signes</h2>
+
+	<p>
+		Les premiers licenciements ont commencé. Aux États-Unis, l'organisation à but non lucratif The
+		Alliance for secure AI a recensé près de 130&nbsp;000 annonces de suppressions d'emplois liées
+		au moins partiellement à l'IA depuis le 1<sup>er</sup> janvier 2025. Certaines professions souvent
+		exercées par des travailleurs indépendants – traducteurs, rédacteurs, développeurs web… – sont déjà
+		en grandes difficultés, les métiers créatifs sont également en première ligne face à la vague de
+		remplacement.
+	</p>
+
+	<p>
+		Enfin, de nombreuses analyses convergent pour s'inquiéter des difficultés croissantes des jeunes
+		diplômés à trouver leur premier emploi. C'est le cas, ironiquement, du patron de la startup
+		Anthropic, Dario Amodei, qui déclarait en mai 2025 au média états-unien Axios :
+	</p>
+
+	<blockquote>
+		<p>
+			« L'IA pourrait effacer la moitié de tous les premiers emplois de cols blancs et faire grimper
+			le chômage à 10-20&nbsp;% d'ici 1 à 5 ans. »
+		</p>
+	</blockquote>
+
+	<h2>Pas de pilote dans l'avion France</h2>
+
+	<p>
+		Avec une IA hors de contrôle, qu'est-ce qui pourrait mal se passer pour notre modèle économique
+		et social ?
+	</p>
+
+	<p>
+		Aucune limite n'arrête pour le moment les géants américains de la tech, ni réglementaire, ni
+		capitalistique, ni physique (énergie). Le développement des modèles d'IA de pointe se poursuit
+		donc, sans autre intention que de les rendre capables de faire aussi bien ou mieux que les
+		humains dans quasiment tous les domaines. Avec, à la clé, la promesse d'une croissance
+		économique à deux chiffres, nécessaire pour assurer la rentabilité future des capitaux investis,
+		mais dont le contenu reste pour le moins flou.
+	</p>
+
+	<h2>À tâtons dans le brouillard</h2>
+
+	<p>
+		Alors, cette croissance ? Il paraît clair que l'IA puisse être plus productive que les humains
+		dans des tâches de plus en plus nombreuses, et par là augmenter les bénéfices des entreprises.
+		On veut bien admettre qu'elle puisse rendre le travail plus intéressant pour les humains en les
+		« augmentant » (mais ça peut aussi être l'inverse). On voit aussi que, même si le processus peut
+		être complexe, le déploiement de l'IA dans les entreprises semble déjà inévitable dans de
+		nombreux domaines : celles qui ne l'utiliseront pas ne pourront pas résister à la concurrence.
+		On verra même se créer des entreprises entièrement pilotées par l'IA, sans employé ou presque.
+	</p>
+
+	<p>
+		Au-delà de ces généralités, personne ne sait dire à quoi l'économie de demain ressemblera, sinon
+		qu'il y aura moins d'humains occupés à des tâches purement intellectuelles ou, à terme, purement
+		manuelles (le développement de la robotique étant également boosté par les progrès de
+		l'intelligence artificielle). L'avenir se laisse d'autant moins appréhender que le moteur de
+		cette mutation est une technologie littéralement incontrôlée, dont les « progrès » vont de pair
+		avec une insécurité croissante.
+	</p>
+
+	<p>
+		Faut-il croire les optimistes pour qui la révolution de l'IA, comme les révolutions
+		industrielles avant elle, va supprimer des emplois pour mieux en créer d'autres et finalement
+		déboucher sur une plus grande prospérité (théorie de la destruction créatrice) ? Non car cette
+		révolution-là est beaucoup plus rapide que les précédentes : tout va beaucoup trop vite, sans
+		stratégie industrielle claire, sans amortisseur social, sans réorientation rapide de notre
+		système éducatif.
+	</p>
+
+	<h2>Le scénario le plus probable : un chômage massif et brutal</h2>
+
+	<p>
+		Dans un premier temps, ce seront surtout les jeunes qui ne trouveront plus d'emploi. Les tâches
+		habituellement confiées à des juniors seront de plus en plus effectuées par l'IA, laquelle sera
+		mise en place et contrôlée par des personnes expérimentées. Outre les préjudices causés aux
+		individus de cette génération, les conséquences systémiques sont graves : les diplômes se
+		démonétisent puisqu'ils ne procurent plus d'emploi. Sans emploi, l'acquisition d'expérience
+		devient impossible, de même que la transmission des plus âgés vers les plus jeunes.
+	</p>
+
+	<p>
+		À la différence de crises précédentes (désindustrialisation, automatisation, informatique,
+		mondialisation) qui ont touché progressivement des travailleurs peu qualifiés ou très
+		spécialisés, les premières tâches automatisables par l'IA sont celles effectuées par des
+		professions intellectuelles aux salaires relativement élevés par rapport à la moyenne. C'est
+		donc un volume important de recettes de cotisations sociales qui est menacé de volatilisation à
+		court terme. L'évolution dépend ensuite des progrès de l'IA, susceptibles de monter à nouveau en
+		flèche et entraînant une nouvelle vague d'automatisation.
+	</p>
+
+	<h2>Notre modèle socio-économique en jeu</h2>
+
+	<p>
+		Il est impensable, dans une économie sans ligne directrice claire, que les personnes déclassées
+		par l'IA puissent acquérir en quelques mois de nouvelles compétences non remplaçables par l'IA
+		(si elles les acquièrent jamais) et trouver un nouvel emploi.
+	</p>
+
+	<p>
+		Ce qui est certain en revanche, c'est qu'une fonte rapide et irréversible des revenus du travail
+		remettrait en cause notre modèle de société. Schématiquement, moins de travail, c'est moins de
+		cotisations sociales donc moins d'argent pour assurer le versement de prestations (assurance
+		chômage, maladie, retraite…). C'est moins de revenus pour vivre, pour consommer et pour faire
+		tourner l'économie des biens et services de consommation.
+	</p>
+
+	<p>
+		Même Sam Altman, le PDG d'OpenAI, s'en inquiète. Dans une note publiée en avril 2026, il enjoint
+		aux pouvoirs publics de considérer des solutions telles qu'un revenu de remplacement, la
+		création d'un fonds alimenté par les entreprises de la tech, ou d'autres.
+	</p>
+
+	<h2>Dépendance inacceptable</h2>
+
+	<p>
+		Méditons sur cette perspective : voulons-nous que nos vies dépendent des revenus d'entreprises
+		hyper-puissantes, dont les produits ont par ailleurs des effets délétères sur nos démocraties,
+		nos cerveaux, notre santé mentale, nos ressources naturelles ? Ou préférons-nous garder le
+		contrôle de notre économie et de notre modèle social ?
+	</p>
+
+	<p>
+		Mais au fond, quel contrôle nous reste-t-il, et comment le conserver ? Dans un monde où la
+		croissance économique dépendra de moins en moins du travail et de plus en plus du capital
+		investi dans l'intelligence artificielle et ses infrastructures, ce sont les revenus de ce
+		capital qui devront être redistribués. Qui décidera si ce capital sera investi dans la santé
+		pour tous et la transition écologique ou dans la guerre et la colonisation de la planète Mars ?
+	</p>
+
+	<p>
+		Derrière la question de l'emploi, c'est véritablement notre monde qui est en jeu. Il faut bien
+		comprendre que les progrès de l'intelligence artificielle générale accélèrent de manière
+		incontrôlée la destruction de notre modèle socio-économique, pour le remplacer par une
+		dépendance gravissime à la superpuissance de la Silicon Valley, des États-Unis et de la Chine.
+	</p>
+
+	<p>
+		Cette perte de souveraineté n'est pas acceptable : nous demandons un moratoire international sur
+		l'entraînement des modèles d'intelligence artificielle de pointe, le temps nécessaire pour que
+		les conditions de sécurité et de contrôle démocratique soient réunies.
+	</p>
+
+	<div class="cta-box">
+		<p class="cta-text">Vous aussi, agissez pour un développement de l'IA sûr et démocratique.</p>
+		<a href="/emploi-ia" class="cta-btn">Je participe à la campagne</a>
+	</div>
+
+	<nav class="back-nav">
+		<a href="/emploi-ia">&larr; Retour à la campagne Emploi et IA</a>
+	</nav>
+</article>
+
+<style>
+	article {
+		max-inline-size: 50rem;
+		margin-inline: auto;
+		margin-top: 2rem;
+		padding: 0 1rem;
+	}
+
+	.intro {
+		font-size: 1.15rem;
+		font-weight: 500;
+		color: var(--brand-subtle, #c96900);
+		border-left: 4px solid var(--brand, #ff9416);
+		background: var(--brand-light, #fff5e8);
+		padding: 1rem 1.25rem;
+		margin: 1.5rem 0;
+	}
+
+	.cta-box {
+		margin: 3rem 0 2rem;
+		padding: 2rem;
+		background: var(--brand-light, #fff5e8);
+		border-left: 4px solid var(--brand, #ff9416);
+		border-radius: 0 12px 12px 0;
+		display: flex;
+		flex-direction: column;
+		align-items: flex-start;
+		gap: 1rem;
+	}
+
+	.cta-text {
+		font-weight: 600;
+		color: var(--brand-subtle, #c96900);
+		margin: 0;
+	}
+
+	.cta-btn {
+		display: inline-block;
+		background: var(--brand, #ff9416);
+		color: white;
+		text-decoration: none;
+		padding: 0.75rem 1.5rem;
+		border-radius: 6px;
+		font-weight: 600;
+		transition: background 0.2s;
+	}
+
+	.cta-btn:hover {
+		background: var(--btn-hover-bg, #ffa945);
+		color: white;
+	}
+
+	.back-nav {
+		margin-top: 3rem;
+		padding-top: 1.5rem;
+		border-top: 1px solid var(--border, #e5e7eb);
+	}
+
+	.back-nav a {
+		color: var(--text-secondary, #676e7a);
+		text-decoration: none;
+		font-size: 0.9375rem;
+		transition: color 0.2s;
+	}
+
+	.back-nav a:hover {
+		color: var(--brand, #ff9416);
+	}
+</style>

--- a/src/routes/emploi-ia/remplacer-humain/+page.svelte
+++ b/src/routes/emploi-ia/remplacer-humain/+page.svelte
@@ -6,12 +6,24 @@
 	<title>Remplacer l'humain, tel est l'objectif | PauseAI France</title>
 	<meta
 		name="description"
-		content="Derrière l'aventure scientifique fascinante de l'intelligence artificielle, c'est bien la prise de contrôle de nos vies, à commencer par notre travail, qui est en jeu."
+		content="En quelques années, l'IA est devenue capable de remplacer les humains dans des tâches de plus en plus nombreuses — 16 % du travail déjà automatisable en France."
 	/>
 	<meta name="robots" content="index, follow" />
 </svelte:head>
 
 <article>
+	<nav class="breadcrumb">
+		<a href="/emploi-ia">← Campagne Emploi &amp; IA</a>
+	</nav>
+
+	<div class="article-meta">
+		<span class="meta-tag">Analyse</span>
+		<span class="meta-sep">·</span>
+		<span class="meta-series">Article 1/2</span>
+		<span class="meta-sep">·</span>
+		<span class="meta-reading">4 min de lecture</span>
+	</div>
+
 	<hgroup>
 		<UnderlinedTitle as="h1">Remplacer l'humain, tel est l'objectif</UnderlinedTitle>
 	</hgroup>
@@ -106,134 +118,20 @@
 			« L'IA pourrait effacer la moitié de tous les premiers emplois de cols blancs et faire grimper
 			le chômage à 10-20&nbsp;% d'ici 1 à 5 ans. »
 		</p>
+		<footer>— Dario Amodei, PDG d'Anthropic, mai 2025</footer>
 	</blockquote>
 
-	<h2>Pas de pilote dans l'avion France</h2>
-
-	<p>
-		Avec une IA hors de contrôle, qu'est-ce qui pourrait mal se passer pour notre modèle économique
-		et social ?
-	</p>
-
-	<p>
-		Aucune limite n'arrête pour le moment les géants américains de la tech, ni réglementaire, ni
-		capitalistique, ni physique (énergie). Le développement des modèles d'IA de pointe se poursuit
-		donc, sans autre intention que de les rendre capables de faire aussi bien ou mieux que les
-		humains dans quasiment tous les domaines. Avec, à la clé, la promesse d'une croissance
-		économique à deux chiffres, nécessaire pour assurer la rentabilité future des capitaux investis,
-		mais dont le contenu reste pour le moins flou.
-	</p>
-
-	<h2>À tâtons dans le brouillard</h2>
-
-	<p>
-		Alors, cette croissance ? Il paraît clair que l'IA puisse être plus productive que les humains
-		dans des tâches de plus en plus nombreuses, et par là augmenter les bénéfices des entreprises.
-		On veut bien admettre qu'elle puisse rendre le travail plus intéressant pour les humains en les
-		« augmentant » (mais ça peut aussi être l'inverse). On voit aussi que, même si le processus peut
-		être complexe, le déploiement de l'IA dans les entreprises semble déjà inévitable dans de
-		nombreux domaines : celles qui ne l'utiliseront pas ne pourront pas résister à la concurrence.
-		On verra même se créer des entreprises entièrement pilotées par l'IA, sans employé ou presque.
-	</p>
-
-	<p>
-		Au-delà de ces généralités, personne ne sait dire à quoi l'économie de demain ressemblera, sinon
-		qu'il y aura moins d'humains occupés à des tâches purement intellectuelles ou, à terme, purement
-		manuelles (le développement de la robotique étant également boosté par les progrès de
-		l'intelligence artificielle). L'avenir se laisse d'autant moins appréhender que le moteur de
-		cette mutation est une technologie littéralement incontrôlée, dont les « progrès » vont de pair
-		avec une insécurité croissante.
-	</p>
-
-	<p>
-		Faut-il croire les optimistes pour qui la révolution de l'IA, comme les révolutions
-		industrielles avant elle, va supprimer des emplois pour mieux en créer d'autres et finalement
-		déboucher sur une plus grande prospérité (théorie de la destruction créatrice) ? Non car cette
-		révolution-là est beaucoup plus rapide que les précédentes : tout va beaucoup trop vite, sans
-		stratégie industrielle claire, sans amortisseur social, sans réorientation rapide de notre
-		système éducatif.
-	</p>
-
-	<h2>Le scénario le plus probable : un chômage massif et brutal</h2>
-
-	<p>
-		Dans un premier temps, ce seront surtout les jeunes qui ne trouveront plus d'emploi. Les tâches
-		habituellement confiées à des juniors seront de plus en plus effectuées par l'IA, laquelle sera
-		mise en place et contrôlée par des personnes expérimentées. Outre les préjudices causés aux
-		individus de cette génération, les conséquences systémiques sont graves : les diplômes se
-		démonétisent puisqu'ils ne procurent plus d'emploi. Sans emploi, l'acquisition d'expérience
-		devient impossible, de même que la transmission des plus âgés vers les plus jeunes.
-	</p>
-
-	<p>
-		À la différence de crises précédentes (désindustrialisation, automatisation, informatique,
-		mondialisation) qui ont touché progressivement des travailleurs peu qualifiés ou très
-		spécialisés, les premières tâches automatisables par l'IA sont celles effectuées par des
-		professions intellectuelles aux salaires relativement élevés par rapport à la moyenne. C'est
-		donc un volume important de recettes de cotisations sociales qui est menacé de volatilisation à
-		court terme. L'évolution dépend ensuite des progrès de l'IA, susceptibles de monter à nouveau en
-		flèche et entraînant une nouvelle vague d'automatisation.
-	</p>
-
-	<h2>Notre modèle socio-économique en jeu</h2>
-
-	<p>
-		Il est impensable, dans une économie sans ligne directrice claire, que les personnes déclassées
-		par l'IA puissent acquérir en quelques mois de nouvelles compétences non remplaçables par l'IA
-		(si elles les acquièrent jamais) et trouver un nouvel emploi.
-	</p>
-
-	<p>
-		Ce qui est certain en revanche, c'est qu'une fonte rapide et irréversible des revenus du travail
-		remettrait en cause notre modèle de société. Schématiquement, moins de travail, c'est moins de
-		cotisations sociales donc moins d'argent pour assurer le versement de prestations (assurance
-		chômage, maladie, retraite…). C'est moins de revenus pour vivre, pour consommer et pour faire
-		tourner l'économie des biens et services de consommation.
-	</p>
-
-	<p>
-		Même Sam Altman, le PDG d'OpenAI, s'en inquiète. Dans une note publiée en avril 2026, il enjoint
-		aux pouvoirs publics de considérer des solutions telles qu'un revenu de remplacement, la
-		création d'un fonds alimenté par les entreprises de la tech, ou d'autres.
-	</p>
-
-	<h2>Dépendance inacceptable</h2>
-
-	<p>
-		Méditons sur cette perspective : voulons-nous que nos vies dépendent des revenus d'entreprises
-		hyper-puissantes, dont les produits ont par ailleurs des effets délétères sur nos démocraties,
-		nos cerveaux, notre santé mentale, nos ressources naturelles ? Ou préférons-nous garder le
-		contrôle de notre économie et de notre modèle social ?
-	</p>
-
-	<p>
-		Mais au fond, quel contrôle nous reste-t-il, et comment le conserver ? Dans un monde où la
-		croissance économique dépendra de moins en moins du travail et de plus en plus du capital
-		investi dans l'intelligence artificielle et ses infrastructures, ce sont les revenus de ce
-		capital qui devront être redistribués. Qui décidera si ce capital sera investi dans la santé
-		pour tous et la transition écologique ou dans la guerre et la colonisation de la planète Mars ?
-	</p>
-
-	<p>
-		Derrière la question de l'emploi, c'est véritablement notre monde qui est en jeu. Il faut bien
-		comprendre que les progrès de l'intelligence artificielle générale accélèrent de manière
-		incontrôlée la destruction de notre modèle socio-économique, pour le remplacer par une
-		dépendance gravissime à la superpuissance de la Silicon Valley, des États-Unis et de la Chine.
-	</p>
-
-	<p>
-		Cette perte de souveraineté n'est pas acceptable : nous demandons un moratoire international sur
-		l'entraînement des modèles d'intelligence artificielle de pointe, le temps nécessaire pour que
-		les conditions de sécurité et de contrôle démocratique soient réunies.
-	</p>
-
-	<div class="cta-box">
-		<p class="cta-text">Vous aussi, agissez pour un développement de l'IA sûr et démocratique.</p>
-		<a href="/emploi-ia" class="cta-btn">Je participe à la campagne</a>
-	</div>
+	<a href="/emploi-ia/pas-de-pilote" class="next-article">
+		<span class="next-label">Article suivant →</span>
+		<strong class="next-title">Pas de pilote dans l'avion France</strong>
+		<span class="next-desc"
+			>Chômage massif, modèle social menacé, dépendance à la Silicon Valley : ce qui nous attend si
+			nous ne réagissons pas.</span
+		>
+	</a>
 
 	<nav class="back-nav">
-		<a href="/emploi-ia">&larr; Retour à la campagne Emploi et IA</a>
+		<a href="/emploi-ia">← Retour à la campagne Emploi &amp; IA</a>
 	</nav>
 </article>
 
@@ -245,6 +143,56 @@
 		padding: 0 1rem;
 	}
 
+	.breadcrumb {
+		margin-bottom: 1.5rem;
+	}
+
+	.breadcrumb a {
+		font-size: 0.875rem;
+		color: var(--text-secondary, #676e7a);
+		text-decoration: none;
+		transition: color 0.2s;
+	}
+
+	.breadcrumb a:hover {
+		color: var(--brand, #ff9416);
+	}
+
+	.article-meta {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		margin-bottom: 1.25rem;
+		flex-wrap: wrap;
+	}
+
+	.meta-tag {
+		font-size: 0.7rem;
+		font-weight: 700;
+		letter-spacing: 0.08em;
+		text-transform: uppercase;
+		color: var(--brand-subtle, #c96900);
+		background: var(--brand-light, #fff5e8);
+		padding: 0.2rem 0.55rem;
+		border-radius: 4px;
+	}
+
+	.meta-sep {
+		color: var(--border, #d1d5db);
+		font-size: 0.8rem;
+	}
+
+	.meta-series {
+		font-size: 0.8125rem;
+		font-weight: 600;
+		color: var(--text-secondary, #555);
+	}
+
+	.meta-reading {
+		font-size: 0.8125rem;
+		color: var(--text-secondary, #888);
+	}
+
 	.intro {
 		font-size: 1.15rem;
 		font-weight: 500;
@@ -252,47 +200,85 @@
 		border-left: 4px solid var(--brand, #ff9416);
 		background: var(--brand-light, #fff5e8);
 		padding: 1rem 1.25rem;
-		margin: 1.5rem 0;
+		margin: 1.5rem 0 2rem;
 	}
 
-	.cta-box {
-		margin: 3rem 0 2rem;
-		padding: 2rem;
-		background: var(--brand-light, #fff5e8);
+	h2 {
+		margin-top: 2.5rem;
+	}
+
+	blockquote {
 		border-left: 4px solid var(--brand, #ff9416);
-		border-radius: 0 12px 12px 0;
+		margin: 2rem 0;
+		padding: 1.25rem 1.5rem;
+		background: var(--bg-subtle, #f7f7f5);
+		border-radius: 0 8px 8px 0;
+	}
+
+	:global([data-theme='dark']) blockquote {
+		background: rgba(255, 255, 255, 0.04);
+	}
+
+	blockquote p {
+		margin: 0 0 0.5rem;
+		font-style: italic;
+		font-size: 1.05rem;
+		color: var(--brand-subtle, #c96900);
+		font-weight: 500;
+	}
+
+	blockquote footer {
+		font-size: 0.8rem;
+		color: var(--text-secondary, #888);
+		font-style: normal;
+	}
+
+	.next-article {
 		display: flex;
 		flex-direction: column;
-		align-items: flex-start;
-		gap: 1rem;
-	}
-
-	.cta-text {
-		font-weight: 600;
-		color: var(--brand-subtle, #c96900);
-		margin: 0;
-	}
-
-	.cta-btn {
-		display: inline-block;
-		background: var(--brand, #ff9416);
-		color: white;
+		gap: 0.4rem;
+		margin: 3rem 0 1.5rem;
+		padding: 1.5rem;
+		border: 1px solid var(--border, #e5e7eb);
+		border-radius: 10px;
 		text-decoration: none;
-		padding: 0.75rem 1.5rem;
-		border-radius: 6px;
-		font-weight: 600;
-		transition: background 0.2s;
+		color: inherit;
+		transition:
+			border-color 0.2s,
+			box-shadow 0.2s;
 	}
 
-	.cta-btn:hover {
-		background: var(--btn-hover-bg, #ffa945);
-		color: white;
+	.next-article:hover {
+		border-color: var(--brand, #ff9416);
+		box-shadow: 0 2px 12px rgba(255, 148, 22, 0.12);
+	}
+
+	.next-label {
+		font-size: 0.75rem;
+		font-weight: 700;
+		letter-spacing: 0.07em;
+		text-transform: uppercase;
+		color: var(--brand-subtle, #c96900);
+	}
+
+	.next-title {
+		font-size: 1rem;
+		font-weight: 700;
+		color: var(--text, #111);
+		display: block;
+	}
+
+	.next-desc {
+		font-size: 0.875rem;
+		color: var(--text-secondary, #676e7a);
+		line-height: 1.5;
 	}
 
 	.back-nav {
-		margin-top: 3rem;
+		margin-top: 2rem;
 		padding-top: 1.5rem;
 		border-top: 1px solid var(--border, #e5e7eb);
+		margin-bottom: 3rem;
 	}
 
 	.back-nav a {


### PR DESCRIPTION
- New section "Nos analyses" with cards linking to both articles
- Article 1 links to existing newsletter on socio-economic threat
- Article 2 is a new static page at /emploi-ia/remplacer-humain with full text about AI replacing human work
- Added i18n strings for FR and EN
- Both lang-prefixed and non-lang routes updated
