### PR TITLE
Fix Activoice embed initialization on emploi-ia page

### DIFF
--- a/src/routes/[lang=lang]/emploi-ia/+page.svelte
+++ b/src/routes/[lang=lang]/emploi-ia/+page.svelte
@@ -84,7 +84,7 @@
 	]
 
 	onMount(() => {
-		const SCRIPT_SRC = 'https://beta.app.activoice.org/embed/v1/loader.js'
+		const SCRIPT_SRC = 'https://app.activoice.org/embed/v1/loader.js'
 
 		function initEmbed() {
 			const w = window as Window & {

--- a/src/routes/[lang=lang]/emploi-ia/+page.svelte
+++ b/src/routes/[lang=lang]/emploi-ia/+page.svelte
@@ -84,17 +84,18 @@
 	]
 
 	onMount(() => {
-		const SCRIPT_SRC = 'https://beta.app.activoice.org/embed/v1/loader.js'
+		const SCRIPT_SRC = 'https://activoice.online/embed/activoice-12.0.0.js'
 
 		function initEmbed() {
 			const w = window as Window & {
-				Activoice?: { init: (opts: Record<string, unknown>) => void }
+				Activoice?: { bootstrap: () => Promise<void> }
 			}
 			if (!w.Activoice) return
-			w.Activoice.init({
-				container: '#av-embed-container',
-				campaignId: ACTIVOICE_CAMPAIGN_ID,
-				embedOptions: { spinnerColor: '#FF9416' }
+			w.Activoice.bootstrap().then(() => {
+				const embed = document.getElementById(
+					'activoice-embed-6b7ceb0e_22b1_48de_b8ae_5617c4920d05'
+				) as HTMLElement & { openWithId?: (id: string) => void }
+				embed?.openWithId?.(ACTIVOICE_CAMPAIGN_ID)
 			})
 		}
 
@@ -195,7 +196,7 @@
 		<p class="cta-callout">{t.emploi_ia.cta_callout}</p>
 		<p class="cta-detail">{t.emploi_ia.cta_callout_detail}</p>
 
-		<div id="av-embed-container" class="av-embed"></div>
+		<activoice-embed id="activoice-embed-6b7ceb0e_22b1_48de_b8ae_5617c4920d05" class="av-embed" />
 	</section>
 
 	<section id="evolution" aria-labelledby="evolution-heading">

--- a/src/routes/[lang=lang]/emploi-ia/+page.svelte
+++ b/src/routes/[lang=lang]/emploi-ia/+page.svelte
@@ -39,7 +39,7 @@
 		image: item.image || '/emploi-ia/article-placeholder.svg'
 	}))
 
-	const ACTIVOICE_CAMPAIGN_ID = '6b7ceb0e-22b1-48de-b8ae-5617c4920d05'
+	const ACTIVOICE_CAMPAIGN_ID = 'lia-ne-detruira-pas-que-votre-emploi'
 
 	const pressArticles = [
 		{

--- a/src/routes/[lang=lang]/emploi-ia/+page.svelte
+++ b/src/routes/[lang=lang]/emploi-ia/+page.svelte
@@ -84,20 +84,37 @@
 	]
 
 	onMount(() => {
-		const init = () => {
-			// @ts-expect-error - Activoice global injected by external script
-			if (typeof window.Activoice !== 'undefined') {
-				// @ts-expect-error
-				window.Activoice.init({
-					container: '#av-embed-container',
-					campaignId: ACTIVOICE_CAMPAIGN_ID,
-					embedOptions: { spinnerColor: '#FF9416' }
-				})
-			} else {
-				setTimeout(init, 100)
+		const SCRIPT_SRC = 'https://beta.app.activoice.org/embed/v1/loader.js'
+
+		function initEmbed() {
+			const w = window as Window & {
+				Activoice?: { init: (opts: Record<string, unknown>) => void }
 			}
+			if (!w.Activoice) return
+			w.Activoice.init({
+				container: '#av-embed-container',
+				campaignId: ACTIVOICE_CAMPAIGN_ID,
+				embedOptions: { spinnerColor: '#FF9416' }
+			})
 		}
-		init()
+
+		const existing = document.querySelector(
+			`script[src="${SCRIPT_SRC}"]`
+		) as HTMLScriptElement | null
+		if (existing) {
+			if ((window as Window & { Activoice?: unknown }).Activoice) {
+				initEmbed()
+			} else {
+				existing.addEventListener('load', initEmbed, { once: true })
+			}
+			return
+		}
+
+		const script = document.createElement('script')
+		script.src = SCRIPT_SRC
+		script.async = true
+		script.addEventListener('load', initEmbed, { once: true })
+		document.head.appendChild(script)
 	})
 </script>
 
@@ -115,7 +132,6 @@
 	<meta name="twitter:title" content={t.emploi_ia.meta_title} />
 	<meta name="twitter:description" content={t.emploi_ia.meta_desc} />
 	<meta name="twitter:image" content="https://pauseia.fr/emploi-ia/emploi-IA.png" />
-	<script src="https://beta.app.activoice.org/embed/v1/loader.js"></script>
 </svelte:head>
 
 <article>
@@ -475,6 +491,5 @@
 	.av-embed {
 		margin-top: 1.5rem;
 		max-width: 100%;
-		overflow: hidden;
 	}
 </style>

--- a/src/routes/[lang=lang]/emploi-ia/+page.svelte
+++ b/src/routes/[lang=lang]/emploi-ia/+page.svelte
@@ -84,18 +84,17 @@
 	]
 
 	onMount(() => {
-		const SCRIPT_SRC = 'https://activoice.online/embed/activoice-12.0.0.js'
+		const SCRIPT_SRC = 'https://beta.app.activoice.org/embed/v1/loader.js'
 
 		function initEmbed() {
 			const w = window as Window & {
-				Activoice?: { bootstrap: () => Promise<void> }
+				Activoice?: { init: (opts: Record<string, unknown>) => void }
 			}
 			if (!w.Activoice) return
-			w.Activoice.bootstrap().then(() => {
-				const embed = document.getElementById(
-					'activoice-embed-6b7ceb0e_22b1_48de_b8ae_5617c4920d05'
-				) as HTMLElement & { openWithId?: (id: string) => void }
-				embed?.openWithId?.(ACTIVOICE_CAMPAIGN_ID)
+			w.Activoice.init({
+				container: '#av-embed-container',
+				campaignId: ACTIVOICE_CAMPAIGN_ID,
+				embedOptions: { spinnerColor: '#FF9416' }
 			})
 		}
 
@@ -196,7 +195,7 @@
 		<p class="cta-callout">{t.emploi_ia.cta_callout}</p>
 		<p class="cta-detail">{t.emploi_ia.cta_callout_detail}</p>
 
-		<activoice-embed id="activoice-embed-6b7ceb0e_22b1_48de_b8ae_5617c4920d05" class="av-embed" />
+		<div id="av-embed-container" class="av-embed"></div>
 	</section>
 
 	<section id="evolution" aria-labelledby="evolution-heading">

--- a/src/routes/[lang=lang]/g7-2026/+page.svelte
+++ b/src/routes/[lang=lang]/g7-2026/+page.svelte
@@ -11,7 +11,7 @@
 		'En 2026, la France accueille le G7. Pause IA demande que la sécurité de l’IA soit remise au cœur de l’agenda international.'
 
 	onMount(() => {
-		const SCRIPT_SRC = 'https://beta.app.activoice.org/embed/v1/loader.js'
+		const SCRIPT_SRC = 'https://app.activoice.org/embed/v1/loader.js'
 
 		function initEmbeds() {
 			const w = window as Window & {

--- a/src/routes/[lang=lang]/g7-2026/+page.svelte
+++ b/src/routes/[lang=lang]/g7-2026/+page.svelte
@@ -11,22 +11,22 @@
 		'En 2026, la France accueille le G7. Pause IA demande que la sécurité de l’IA soit remise au cœur de l’agenda international.'
 
 	onMount(() => {
-		const SCRIPT_SRC = 'https://activoice.online/embed/activoice-12.0.0.js'
+		const SCRIPT_SRC = 'https://beta.app.activoice.org/embed/v1/loader.js'
 
 		function initEmbeds() {
 			const w = window as Window & {
-				Activoice?: { bootstrap: () => Promise<void> }
+				Activoice?: { init: (opts: Record<string, unknown>) => void }
 			}
 			if (!w.Activoice) return
-			w.Activoice.bootstrap().then(() => {
-				const embed1 = document.getElementById(
-					'activoice-embed-ffccd310_c37c_406b_8425_0225f237857b'
-				) as HTMLElement & { openWithId?: (id: string) => void }
-				embed1?.openWithId?.(CAMPAIGN_ID)
-				const embed2 = document.getElementById(
-					'activoice-embed-c858d3be_34d3_4478_b199_0b8d01fcdc4e'
-				) as HTMLElement & { openWithId?: (id: string) => void }
-				embed2?.openWithId?.(CAMPAIGN_ID_G7)
+			w.Activoice.init({
+				container: '#av-embed-container',
+				campaignId: CAMPAIGN_ID,
+				embedOptions: { spinnerColor: '#005DCA' }
+			})
+			w.Activoice.init({
+				container: '#av-embed-container-g7',
+				campaignId: CAMPAIGN_ID_G7,
+				embedOptions: { spinnerColor: '#005DCA' }
 			})
 		}
 
@@ -119,7 +119,7 @@
 	</section>
 
 	<section class="embed-section">
-		<activoice-embed id="activoice-embed-ffccd310_c37c_406b_8425_0225f237857b" />
+		<div id="av-embed-container"></div>
 	</section>
 
 	<section class="prose">
@@ -130,7 +130,7 @@
 	</section>
 
 	<section class="embed-section">
-		<activoice-embed id="activoice-embed-c858d3be_34d3_4478_b199_0b8d01fcdc4e" />
+		<div id="av-embed-container-g7"></div>
 	</section>
 </article>
 
@@ -180,8 +180,8 @@
 		margin-bottom: 5rem;
 	}
 
-	activoice-embed {
-		display: block;
+	#av-embed-container,
+	#av-embed-container-g7 {
 		min-height: 400px;
 	}
 

--- a/src/routes/[lang=lang]/g7-2026/+page.svelte
+++ b/src/routes/[lang=lang]/g7-2026/+page.svelte
@@ -3,8 +3,8 @@
 	import PostMeta from '$components/PostMeta.svelte'
 	import UnderlinedTitle from '$components/UnderlinedTitle.svelte'
 
-	const CAMPAIGN_ID = 'ffccd310-c37c-406b-8425-0225f237857b'
-	const CAMPAIGN_ID_G7 = 'c858d3be-34d3-4478-b199-0b8d01fcdc4e'
+	const CAMPAIGN_ID = 'interpellez-les-dirigeants-du-g7-en-vue-du-sommet-devian'
+	const CAMPAIGN_ID_G7 = 'call-on-g7-leaders-ahead-of-the-evian-summit'
 
 	const title = 'G7 2026 : sécuriser plutôt qu’accélérer l’IA'
 	const description =

--- a/src/routes/[lang=lang]/g7-2026/+page.svelte
+++ b/src/routes/[lang=lang]/g7-2026/+page.svelte
@@ -11,22 +11,22 @@
 		'En 2026, la France accueille le G7. Pause IA demande que la sécurité de l’IA soit remise au cœur de l’agenda international.'
 
 	onMount(() => {
-		const SCRIPT_SRC = 'https://beta.app.activoice.org/embed/v1/loader.js'
+		const SCRIPT_SRC = 'https://activoice.online/embed/activoice-12.0.0.js'
 
 		function initEmbeds() {
 			const w = window as Window & {
-				Activoice?: { init: (opts: Record<string, unknown>) => void }
+				Activoice?: { bootstrap: () => Promise<void> }
 			}
 			if (!w.Activoice) return
-			w.Activoice.init({
-				container: '#av-embed-container',
-				campaignId: CAMPAIGN_ID,
-				embedOptions: { spinnerColor: '#005DCA' }
-			})
-			w.Activoice.init({
-				container: '#av-embed-container-g7',
-				campaignId: CAMPAIGN_ID_G7,
-				embedOptions: { spinnerColor: '#005DCA' }
+			w.Activoice.bootstrap().then(() => {
+				const embed1 = document.getElementById(
+					'activoice-embed-ffccd310_c37c_406b_8425_0225f237857b'
+				) as HTMLElement & { openWithId?: (id: string) => void }
+				embed1?.openWithId?.(CAMPAIGN_ID)
+				const embed2 = document.getElementById(
+					'activoice-embed-c858d3be_34d3_4478_b199_0b8d01fcdc4e'
+				) as HTMLElement & { openWithId?: (id: string) => void }
+				embed2?.openWithId?.(CAMPAIGN_ID_G7)
 			})
 		}
 
@@ -119,7 +119,7 @@
 	</section>
 
 	<section class="embed-section">
-		<div id="av-embed-container"></div>
+		<activoice-embed id="activoice-embed-ffccd310_c37c_406b_8425_0225f237857b" />
 	</section>
 
 	<section class="prose">
@@ -130,7 +130,7 @@
 	</section>
 
 	<section class="embed-section">
-		<div id="av-embed-container-g7"></div>
+		<activoice-embed id="activoice-embed-c858d3be_34d3_4478_b199_0b8d01fcdc4e" />
 	</section>
 </article>
 
@@ -180,8 +180,8 @@
 		margin-bottom: 5rem;
 	}
 
-	#av-embed-container,
-	#av-embed-container-g7 {
+	activoice-embed {
+		display: block;
 		min-height: 400px;
 	}
 


### PR DESCRIPTION
The script was loaded via <svelte:head> which caused it to execute before the container div existed in the DOM during SSR hydration, leading to a double-init race condition where the iframe loaded but stayed in its loading state (visibility: hidden) forever.

Switch to the same onMount dynamic loading pattern already used on the g7-2026 page, and remove overflow: hidden from the embed wrapper which could interfere with the embed's layout calculations.

