### PR TITLE
Add noindex meta to error pages

### DIFF
--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -34,6 +34,7 @@
 
 <svelte:head>
 	<title>{status} — {info.title} | Pause IA</title>
+	<meta name="robots" content="noindex, nofollow" />
 </svelte:head>
 
 <div class="error-page">


### PR DESCRIPTION
Google indexed a 500 page as the homepage result. Add robots noindex on the error route so transient server errors no longer pollute SERPs.