### PR TITLE
Add Google Search Console verification file and noindex on error pages

### DIFF
--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -34,6 +34,7 @@
 
 <svelte:head>
 	<title>{status} — {info.title} | Pause IA</title>
+	<meta name="robots" content="noindex, nofollow" />
 </svelte:head>
 
 <div class="error-page">

--- a/static/google53f2dabbb52c7fd5.html
+++ b/static/google53f2dabbb52c7fd5.html
@@ -1,0 +1,1 @@
+google-site-verification: google53f2dabbb52c7fd5.html


### PR DESCRIPTION
- static/google53f2dabbb52c7fd5.html for GSC URL-prefix verification
- noindex/nofollow meta on +error.svelte so transient 500s don't get indexed as the homepage