### PR TITLE
feat(campagnes): clôturer la campagne Genève 2026, prioriser élus > e…

### DIFF
--- a/src/lib/campaigns.ts
+++ b/src/lib/campaigns.ts
@@ -79,10 +79,29 @@ export interface Campaign {
 export const campaigns: Campaign[] = [
 	{
 		slug: 'geneve-2026',
-		status: 'active',
+		status: 'ended',
 		startDate: '2026-07',
+		endDate: '2026-07',
 		// Déposer l'image dans static/campaigns/geneve-2026.jpg (CC0 / domaine public).
 		image: '/campaigns/geneve-2026.jpg',
+		summary: {
+			fr: {
+				text: "Les 6 et 7 juillet 2026, l'ONU a réuni à Genève la première session du Dialogue mondial sur la gouvernance de l'intelligence artificielle. Pause IA a interpellé la délégation française pour lui demander de soutenir un traité international instaurant une pause sur les modèles d'IA les plus avancés : plus de 1 000 mails lui ont été adressés pendant la campagne. Le 6 juillet, le Groupe scientifique international indépendant sur l'IA (37 scientifiques, présidé par Yoshua Bengio et Maria Ressa) a présenté son premier rapport, confirmant que « les capacités de l'intelligence artificielle évoluent plus rapidement que notre aptitude à les évaluer ou à les maîtriser ». Pause IA a salué ces travaux tout en appelant à agir sans délai : « la sécurité des citoyens, la souveraineté démocratique et l'avenir de nos sociétés doivent primer sur les intérêts d'une minorité d'acteurs privés », a déclaré Clémence Peyrot, directrice exécutive de Pause IA.",
+				results: [
+					{ label: 'Mails envoyés à la délégation française', value: '+1 000' },
+					{ label: 'Rapport scientifique cité', value: '37 scientifiques (Bengio, Ressa)' },
+					{ label: 'Sondage OpinionWay cité', value: '8 % favorables à une accélération' }
+				]
+			},
+			en: {
+				text: 'On 6-7 July 2026, the UN convened the first session of the Global Dialogue on AI Governance in Geneva. Pause AI called on the French delegation to support an international treaty establishing a pause on the most advanced AI models: more than 1,000 emails were sent to it during the campaign. On 6 July, the International Independent Scientific Panel on AI (37 scientists, chaired by Yoshua Bengio and Maria Ressa) presented its first report, confirming that "AI capabilities are advancing faster than our ability to evaluate or control them." Pause AI welcomed this work while calling for immediate action: "the safety of citizens, democratic sovereignty and the future of our societies must come before the interests of a minority of private actors," said Clémence Peyrot, Executive Director of Pause AI.',
+				results: [
+					{ label: 'Emails sent to the French delegation', value: '1,000+' },
+					{ label: 'Scientific report cited', value: '37 scientists (Bengio, Ressa)' },
+					{ label: 'OpinionWay poll cited', value: '8% in favour of acceleration' }
+				]
+			}
+		},
 		fr: {
 			title: 'Genève 2026 : soutenir un traité international sur l’IA',
 			homeTitle: 'Demandez à la France de soutenir un traité international sur l’IA',
@@ -213,9 +232,6 @@ export const campaigns: Campaign[] = [
 		slug: 'emploi-ia',
 		status: 'active',
 		startDate: '2026-04',
-		// Temporairement masquée de la section campagnes de la page d'accueil
-		// (reste accessible sur /campagnes et dans le menu).
-		homeHidden: true,
 		image: '/campaigns/DSC08648_r.webp',
 		fr: {
 			title: "L'IA ne détruira pas QUE votre emploi",

--- a/src/lib/campaigns.ts
+++ b/src/lib/campaigns.ts
@@ -87,19 +87,11 @@ export const campaigns: Campaign[] = [
 		summary: {
 			fr: {
 				text: "Les 6 et 7 juillet 2026, l'ONU a réuni à Genève la première session du Dialogue mondial sur la gouvernance de l'intelligence artificielle. Pause IA a interpellé la délégation française pour lui demander de soutenir un traité international instaurant une pause sur les modèles d'IA les plus avancés : plus de 1 000 mails lui ont été adressés pendant la campagne. Le 6 juillet, le Groupe scientifique international indépendant sur l'IA (37 scientifiques, présidé par Yoshua Bengio et Maria Ressa) a présenté son premier rapport, confirmant que « les capacités de l'intelligence artificielle évoluent plus rapidement que notre aptitude à les évaluer ou à les maîtriser ». Pause IA a salué ces travaux tout en appelant à agir sans délai : « la sécurité des citoyens, la souveraineté démocratique et l'avenir de nos sociétés doivent primer sur les intérêts d'une minorité d'acteurs privés », a déclaré Clémence Peyrot, directrice exécutive de Pause IA.",
-				results: [
-					{ label: 'Mails envoyés à la délégation française', value: '+1 000' },
-					{ label: 'Rapport scientifique cité', value: '37 scientifiques (Bengio, Ressa)' },
-					{ label: 'Sondage OpinionWay cité', value: '8 % favorables à une accélération' }
-				]
+				results: [{ label: 'Mails envoyés à la délégation française', value: '+1 000' }]
 			},
 			en: {
 				text: 'On 6-7 July 2026, the UN convened the first session of the Global Dialogue on AI Governance in Geneva. Pause AI called on the French delegation to support an international treaty establishing a pause on the most advanced AI models: more than 1,000 emails were sent to it during the campaign. On 6 July, the International Independent Scientific Panel on AI (37 scientists, chaired by Yoshua Bengio and Maria Ressa) presented its first report, confirming that "AI capabilities are advancing faster than our ability to evaluate or control them." Pause AI welcomed this work while calling for immediate action: "the safety of citizens, democratic sovereignty and the future of our societies must come before the interests of a minority of private actors," said Clémence Peyrot, Executive Director of Pause AI.',
-				results: [
-					{ label: 'Emails sent to the French delegation', value: '1,000+' },
-					{ label: 'Scientific report cited', value: '37 scientists (Bengio, Ressa)' },
-					{ label: 'OpinionWay poll cited', value: '8% in favour of acceleration' }
-				]
+				results: [{ label: 'Emails sent to the French delegation', value: '1,000+' }]
 			}
 		},
 		fr: {

--- a/src/lib/components/Header.svelte
+++ b/src/lib/components/Header.svelte
@@ -98,7 +98,6 @@
 			label: t.nav.campagnes,
 			items: [
 				{ href: `${prefix}/campagnes`, label: t.nav.toutes_campagnes },
-				{ href: `${prefix}/geneve-2026`, label: t.nav.geneve_2026 },
 				{ href: `${prefix}/ecrire-a-mes-elus`, label: t.nav.ecrire_elus },
 				{ href: `${prefix}/emploi-ia`, label: t.nav.emploi_ia }
 			]

--- a/src/lib/components/home/campaigns.svelte
+++ b/src/lib/components/home/campaigns.svelte
@@ -14,10 +14,10 @@
 		.filter((c) => c.status === 'active' && !c.homeHidden)
 		.slice(0, 3)
 
-	// First campaign (highest priority) is featured; the rest show smaller
-	// in a grid below. With a single active campaign, no featured card.
-	$: featured = activeCampaigns.length >= 2 ? activeCampaigns[0] : null
-	$: secondary = activeCampaigns.length >= 2 ? activeCampaigns.slice(1) : activeCampaigns
+	// With 3 campaigns: 1 featured + 2 secondary in a grid.
+	// With 1-2 campaigns: show them side-by-side (same size), ordered by priority.
+	$: featured = activeCampaigns.length >= 3 ? activeCampaigns[0] : null
+	$: secondary = activeCampaigns.length >= 3 ? activeCampaigns.slice(1) : activeCampaigns
 
 	const label_id = 'home-campaigns-title'
 </script>
@@ -68,7 +68,7 @@
 		{/if}
 
 		{#if secondary.length > 0}
-			<div class="grid" class:single={secondary.length === 1}>
+			<div class="grid">
 				{#each secondary as campaign}
 					{@const info = lang === 'en' ? campaign.en : campaign.fr}
 					{@const href = campaign.url ?? `${prefix}/${campaign.slug}`}
@@ -307,11 +307,6 @@
 	@media (min-width: 640px) {
 		.grid {
 			grid-template-columns: repeat(2, 1fr);
-		}
-
-		.grid.single {
-			grid-template-columns: 1fr;
-			max-width: 26rem;
 		}
 	}
 

--- a/src/lib/components/home/campaigns.svelte
+++ b/src/lib/components/home/campaigns.svelte
@@ -14,10 +14,10 @@
 		.filter((c) => c.status === 'active' && !c.homeHidden)
 		.slice(0, 3)
 
-	// With 3 campaigns: 1 featured + 2 secondary in a grid.
-	// With 2 campaigns: show both side-by-side, no featured.
-	$: featured = activeCampaigns.length >= 3 ? activeCampaigns[0] : null
-	$: secondary = activeCampaigns.length >= 3 ? activeCampaigns.slice(1) : activeCampaigns
+	// First campaign (highest priority) is featured; the rest show smaller
+	// in a grid below. With a single active campaign, no featured card.
+	$: featured = activeCampaigns.length >= 2 ? activeCampaigns[0] : null
+	$: secondary = activeCampaigns.length >= 2 ? activeCampaigns.slice(1) : activeCampaigns
 
 	const label_id = 'home-campaigns-title'
 </script>
@@ -68,7 +68,7 @@
 		{/if}
 
 		{#if secondary.length > 0}
-			<div class="grid">
+			<div class="grid" class:single={secondary.length === 1}>
 				{#each secondary as campaign}
 					{@const info = lang === 'en' ? campaign.en : campaign.fr}
 					{@const href = campaign.url ?? `${prefix}/${campaign.slug}`}
@@ -307,6 +307,11 @@
 	@media (min-width: 640px) {
 		.grid {
 			grid-template-columns: repeat(2, 1fr);
+		}
+
+		.grid.single {
+			grid-template-columns: 1fr;
+			max-width: 26rem;
 		}
 	}
 

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -55,6 +55,8 @@ const config = {
 							'/en/sommet-ia-2026',
 							'/fr/g7-2026',
 							'/en/g7-2026',
+							'/fr/geneve-2026',
+							'/en/geneve-2026',
 							'/fr/emploi-ia',
 							'/en/emploi-ia',
 							'/fr/emploi-ia/questionnaire',


### PR DESCRIPTION
…mploi-IA

La campagne Genève 2026 passe en "terminée" avec un bilan (résumé, mails envoyés, rapport scientifique, sondage) affiché dans la modale de /campagnes, comme les autres campagnes closes.

Sur la page d'accueil, la campagne "Écrivez à vos élus" devient la campagne mise en avant et "L'IA ne détruira pas QUE votre emploi" (jusqu'ici masquée) apparaît en second, dans une carte plus discrète.