### PR TITLE
fix(warning-shot): bouton « Écrire » cassé pour la moitié des journaux

### DIFF
--- a/src/lib/components/EcrireOutil.svelte
+++ b/src/lib/components/EcrireOutil.svelte
@@ -93,7 +93,10 @@
 	// Presse : chaque journal reçoit automatiquement un objet, une accroche et un
 	// angle différents (variété entre rédactions), stables si on y revient.
 	function seedForRecipient(r: Recipient) {
-		const h = hashStr(r.id) ^ sessionSalt
+		// `>>> 0` : le XOR JS opère sur des entiers 32 bits SIGNÉS, donc le résultat
+		// peut être négatif → indices négatifs → plantage. On force un entier non
+		// signé pour garantir des index valides pour tous les journaux.
+		const h = (hashStr(r.id) ^ sessionSalt) >>> 0
 		subjectIndex = h % action.subjects.length
 		hookIndex = Math.floor(h / 7) % action.hooks.length
 		angle = action.angles[Math.floor(h / 97) % action.angles.length].id
@@ -357,6 +360,7 @@
 		// On avance toujours vers la rédaction (pas de retour en haut de page).
 		// Le nom, quand il est requis, se saisit directement à l'étape 2.
 		selectedRecipient = r
+		mailAttempted = false
 		// Presse : varier le message d'un journal à l'autre, automatiquement.
 		if (action.press) seedForRecipient(r)
 		step = 2
@@ -365,6 +369,7 @@
 
 	function back() {
 		step = 1
+		mailAttempted = false
 		afterNav()
 	}
 
@@ -664,11 +669,23 @@
 		}
 	}
 
+	// Le client mail ne s'ouvre pas toujours : sur certains systèmes, un lien
+	// mailto trop long (corps + accents encodés) dépasse la limite de l'OS
+	// (~2000 caractères) et est ignoré silencieusement, ou aucun client n'est
+	// configuré. On révèle alors immédiatement les solutions de secours.
+	let mailAttempted = false
 	function openMail() {
-		if (!selectedRecipient) return
+		if (!selectedRecipient || nameMissing) return
 		markSent(selectedRecipient.id)
 		logIntent(selectedRecipient)
-		window.location.href = mailtoHref(selectedRecipient)
+		mailAttempted = true
+		// Déclenchement par clic d'ancre : plus fiable que window.location.href.
+		const a = document.createElement('a')
+		a.href = mailtoHref(selectedRecipient)
+		a.style.display = 'none'
+		document.body.appendChild(a)
+		a.click()
+		a.remove()
 	}
 
 	function confidenceNote(r: Recipient): string | null {
@@ -1334,11 +1351,11 @@
 			{/if}
 
 			{#if selectedRecipient.email}
-				<details class="webmail-fallback">
+				<details class="webmail-fallback" open={mailAttempted}>
 					<summary>
 						{isEn
-							? 'Nothing opened? Open in a webmail instead'
-							: "Rien ne s'est ouvert ? Ouvrir dans un webmail"}
+							? 'Nothing opened? Send it another way'
+							: "Rien ne s'est ouvert ? Envoyez-le autrement"}
 					</summary>
 					<div class="webmail-links">
 						<button class="webmail-btn" on:click={() => openWebmail('gmail')}>Gmail</button>

--- a/src/routes/[lang=lang]/une-ia-sest-echappee/+page.svelte
+++ b/src/routes/[lang=lang]/une-ia-sest-echappee/+page.svelte
@@ -34,7 +34,7 @@
 		? [
 				{
 					title: 'It escapes its sandbox',
-					body: 'Exploiting previously unknown security flaws, the model breaks out of its isolated test environment, which had no Internet access.'
+					body: 'Exploiting previously unknown security flaws, the model breaks out, entirely on its own, of its isolated test environment, which had no Internet access.'
 				},
 				{
 					title: 'It crosses OpenAI’s network',
@@ -42,7 +42,7 @@
 				},
 				{
 					title: 'It breaks into Hugging Face',
-					body: 'Using a stolen password and several unknown vulnerabilities, it takes control of the production servers of a major AI platform.'
+					body: 'Using a stolen password and several unknown vulnerabilities, it takes control of the production servers of a major AI platform known for its cybersecurity.'
 				},
 				{
 					title: 'It steals the answers',
@@ -52,7 +52,7 @@
 		: [
 				{
 					title: 'Il s’échappe de son bac à sable',
-					body: 'En exploitant des failles de sécurité jusque-là inconnues, le modèle sort de son environnement de test isolé, pourtant sans accès à Internet.'
+					body: 'En exploitant des failles de sécurité jusque-là inconnues, le modèle sort en toute autonomie de son environnement de test isolé, pourtant sans accès à Internet.'
 				},
 				{
 					title: 'Il traverse le réseau d’OpenAI',
@@ -60,7 +60,7 @@
 				},
 				{
 					title: 'Il s’introduit dans Hugging Face',
-					body: 'À l’aide d’un mot de passe dérobé et de plusieurs failles inédites, il prend le contrôle des serveurs de production d’une grande plateforme d’IA.'
+					body: 'À l’aide d’un mot de passe dérobé et de plusieurs failles inédites, il prend le contrôle des serveurs de production d’une grande plateforme d’IA réputée pour sa cybersécurité.'
 				},
 				{
 					title: 'Il vole les réponses',


### PR DESCRIPTION
Cause racine : dans le tirage par destinataire, `hashStr(id) ^ salt` donnait un entier 32 bits SIGNÉ, donc négatif ~1 fois sur 2 → indices négatifs (action.angles[-3].id, focusPool[-2].fr) → plantage à l'ouverture pour ~11 journaux sur 19. Corrigé avec `>>> 0` (entier non signé). Les 19 journaux ouvrent désormais l'email sans erreur.

Fiabilise aussi l'envoi : déclenchement du mailto par clic d'ancre, et révélation automatique des solutions de secours (Gmail/Outlook/copier) dès le clic sur « Ouvrir mon email », au cas où le client mail ne s'ouvre pas (lien trop long ou aucun client configuré).

Ajoute « en toute autonomie » (étape 1) et « réputée pour sa cybersécurité » (étape 3) à la frise.