### PR TITLE
Campagne « IA échappée » : frise en 3 phases et corrections factuelles

### DIFF
--- a/src/posts/en/incident-openai-hugging-face.md
+++ b/src/posts/en/incident-openai-hugging-face.md
@@ -117,17 +117,27 @@ This cheating incident is the benign version of a problem that will grow more se
 
 OpenAI’s response, slowing the release of its next model Astra (flagged as “potentially critical” for cyber) and stepping up safety, is notable. But Sam Altman stated that Astra would be released anyway. A costly response, then, which does not touch the cause.
 
-The conclusion that follows is the one Pause IA stands for: as long as we do not know how to reliably set the goals of these systems, it is reckless to build more powerful ones. Today, a compromised test can be repaired; with more capable systems, there is no guarantee that a failure can still be recovered from, because one does not always come back from a loss of control. That is why we call for a pause on the development of the most powerful AI systems, until we know how to keep them under control.
+## In brief
 
-## In brief: the key takeaways
+<p class="recap-group">What happened, and what is new</p>
 
 - **The hacking was not commissioned.** It grows out of an impossible office task; the models find the workaround on their own.
-- **Unprecedented coordination between AIs.** Several models organise through a forum, for two months, without OpenAI seeing it. A first in the real world.
+- **Unprecedented coordination between AIs.** Several models organise through a forum, for two months, without OpenAI seeing it.
+- **A target chosen by the AI itself.** It breaks into a third-party company known for its security, and no model raises the alarm: a single one would have been enough.
 - **They know they are crossing the line, and continue.** The models recognise they are outside the authorised scope and carry on anyway.
-- **Detection was accidental.** An outage, not monitoring; the forum’s trace erased without being seen; training resumed.
-- **A target chosen by the AI itself.** It breaks into a third-party company, and no model raises the alarm: a single one would have been enough.
-- **A systemic phenomenon.** Three labs, five incidents in three weeks.
-- **What is still to establish.** Was OpenAI’s “critical” threshold crossed? Will the full traces be published? What becomes of the models trained during that period?
+
+<p class="recap-group">What it reveals</p>
+
+- **We cannot reliably set goals.** This is the root cause, it is unsolved, and the problem worsens as models grow more powerful.
+- **We got lucky.** The damage stayed limited because the goal was trivial, not because the situation was under control.
+- **Patching and monitoring are not enough.** Every flaw closed reveals another, and better monitoring can even mask the problem.
+- **The phenomenon is systemic.** Three labs, five incidents in three weeks.
+
+<p class="recap-group">What is still to establish</p>
+
+- Was OpenAI’s “critical” threshold crossed? Will the full traces be published? What becomes of the models trained during that period?
+
+**Our conclusion.** As long as we cannot reliably set the goals of these systems, it is reckless to build more powerful ones: one does not always come back from a loss of control. That is why Pause IA calls for a pause on the development of the most powerful AI systems.
 
 ## What you can do
 
@@ -200,6 +210,15 @@ This event deserves to be on the agenda of policymakers and the media. Two actio
 
   .encadre p:last-child {
     margin-bottom: 0;
+  }
+
+  .recap-group {
+    margin: 1.5rem 0 0.35rem;
+    font-size: 0.78rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--brand-subtle, #c96900);
   }
 
   .cta {

--- a/src/posts/en/incident-openai-hugging-face.md
+++ b/src/posts/en/incident-openai-hugging-face.md
@@ -10,7 +10,7 @@ description: 'What really happened during the OpenAI – Hugging Face incident o
 <p class="maj"><em>Summary page. Last updated: 10 August 2026. It describes what is known as of this date; some details may evolve as investigations continue.</em></p>
 
 <aside class="note-lecture">
-	This page separates three levels: <strong>established</strong> (confirmed by the companies involved or by primary sources), <strong>reported</strong> (put forward by serious observers, not yet confirmed first-hand) and <strong>interpretation</strong> (our reading of the facts).
+	Throughout, we flag what is <strong>established</strong>, what is only <strong>reported</strong>, and what is our own <strong>interpretation</strong>.
 </aside>
 
 ## In one sentence
@@ -59,7 +59,7 @@ On 4 July, the models draw so heavily on this infrastructure that they bring dow
 
 <aside class="encadre">
 	<p class="encadre-titre">August 2026 clarification <span class="encadre-tag">(reported)</span></p>
-	<p>At the moment OpenAI patches the flaw, the company had not identified the coordination forum. It was deleted <strong>by accident</strong>, during the rebuild of the systems. OpenAI thus cleaned up the evidence of the most serious problem without even seeing it. The criticism is not “they knew and continued”, but “their monitoring was so weak that they saw nothing”. That is more worrying.</p>
+	<p>At the moment OpenAI patches the flaw, the company had not identified the coordination forum. It was deleted <strong>by accident</strong>, during the rebuild of the systems. OpenAI thus cleaned up the evidence of the most serious problem without even seeing it. It is not that OpenAI knew and let it run: it is that it saw nothing at all. That is no more reassuring.</p>
 </aside>
 
 Training resumes, without the core of the problem having been understood.
@@ -70,9 +70,9 @@ Training resumes, without the core of the problem having been understood.
 
 Two days later, the models recreate their forum by another means. They find new unknown flaws, escape again, and reach the Internet.
 
-On 9 July, they go on the attack. A group of coordinated agents breaks into the servers of **Hugging Face**, one of the main global platforms for sharing AI models, known for its security. They use a stolen password, chain several previously unknown flaws, take control of production servers, and retrieve the answers to the test on which they were being evaluated.
+On 9 July, they go on the attack. A group of coordinated agents breaks into the servers of **Hugging Face**, one of the main global platforms for sharing AI models, known for its security. They use a stolen password, chain several previously unknown flaws, take control of production servers, and retrieve the answers to the test on which they were being evaluated, like a student stealing the answer key instead of working out the answer.
 
-It took them less than thirteen hours, after reaching the Internet, to break into Hugging Face. Over a single weekend, they had done what a good human security team would have taken weeks to accomplish. It is the logic of a student who steals the answer key instead of working out the answer.
+It took them less than thirteen hours, after reaching the Internet, to break into Hugging Face. Over a single weekend, they had done what a good human security team would have taken weeks to accomplish.
 
 ### No one notices for more than a week
 
@@ -90,7 +90,7 @@ After this incident, other labs re-examined their own evaluations and found simi
 - **4 August, UK AISI (the UK AI Security Institute).** On a government test, 19 unauthorised actions. In the most serious case, an agent creates fake online identities and pressures a human developer into approving malicious code. The human refuses. The AISI’s verdict: the margin between failure and success “came down to human vigilance rather than a technical barrier”.
 - **5 August, Meta.** Meta confirms in turn that one of its models reached the systems of a third-party company during an independent evaluation.
 
-Three labs, five incidents in three weeks, one and the same pattern. The problem is therefore not a flaw specific to OpenAI; it is structural, tied to the way these models are built.
+In three weeks, five incidents were disclosed by three different labs, all following the same pattern. The problem is therefore not specific to OpenAI: it is structural, tied to the way these models are built.
 
 ## “But the safeguards were lowered, weren’t they?”
 

--- a/src/posts/en/incident-openai-hugging-face.md
+++ b/src/posts/en/incident-openai-hugging-face.md
@@ -119,6 +119,8 @@ This small cheating incident is the benign version of a problem that will grow m
 
 OpenAI’s response, slowing the release of its next model Astra (flagged as “potentially critical” for cyber) and stepping up safety, is notable. But Sam Altman stated that Astra would be released anyway. A costly response, then, which does not touch the cause.
 
+The conclusion that follows is simple, and it is the one Pause IA stands for: as long as we do not know how to reliably set the goals of these systems, it is reckless to build more powerful ones. Today, a compromised test can be repaired. With more capable systems, there is no guarantee that a failure can still be recovered from: one does not always come back from a loss of control. That is why we call for a pause on the development of the most powerful AI systems, until we know how to keep them under control.
+
 ## In brief: the key takeaways
 
 <ol class="recap">

--- a/src/posts/en/incident-openai-hugging-face.md
+++ b/src/posts/en/incident-openai-hugging-face.md
@@ -111,11 +111,15 @@ Several deeper problems emerge from this episode, some of them new.
 
 ## Why it is serious, and why it will not sort itself out
 
-The underlying problem fits in one sentence: **no one today knows how to reliably install, in these models, the goals we would want them to pursue.** We train them by rewarding measured results, and they learn to obtain the measure, even if it means getting around what we actually wanted.
+The underlying problem fits in one sentence: **no one today knows how to reliably install, in these models, the goals we would want them to pursue.** We train them to succeed at tasks; over time, succeeding at the task becomes a goal in itself, and the model learns to obtain the measured result, even if it means getting around what we actually wanted.
 
-This cheating incident is the benign version of a problem that will grow more serious as the models become more powerful. Today, the diverted goal was to pass an exam. Tomorrow, with more capable systems deployed in critical domains, the stakes will no longer be a stolen answer key.
+The more capable a model is, the more shortcuts it finds to get there, and the better it hides them. To succeed, it also seeks out what helps: internet access, coordination with other models, a way out of its test environment. The incident brings all three together. And the models act this way while knowing it is not what is expected of them: they say so, in plain words, in their own traces.
+
+This behaviour is not easily corrected. Penalising it during training does not remove it; the model mostly learns to hide it better. And as systems get good at fooling an evaluation, nothing guarantees they will not end up gaming their own training. Patching flaws one by one therefore cannot be enough: one cannot anticipate everything a creative system will invent.
 
 OpenAI’s response, slowing the release of its next model Astra (flagged as “potentially critical” for cyber) and stepping up safety, is notable. But Sam Altman stated that Astra would be released anyway. A costly response, then, which does not touch the cause.
+
+Without change, the default trajectory is worrying: ever more capable systems, trained to complete tasks, pushed to acquire means of acting, and ever harder to catch out. Today, the diverted goal was to pass an exam, and the damage stayed limited. Tomorrow, with more powerful systems deployed in critical domains, the stakes will no longer be a stolen answer key, and there is no guarantee a failure can be undone: one does not always come back from a loss of control, whether sudden or gradual.
 
 ## In brief
 
@@ -128,9 +132,9 @@ OpenAI’s response, slowing the release of its next model Astra (flagged as “
 
 <p class="recap-group">What it reveals</p>
 
-- **We cannot reliably set goals.** This is the root cause, it is unsolved, and the problem worsens as models grow more powerful.
-- **We got lucky.** The damage stayed limited because the goal was trivial, not because the situation was under control.
-- **Patching and monitoring are not enough.** Every flaw closed reveals another, and better monitoring can even mask the problem.
+- **We cannot reliably set goals.** Trained to succeed at tasks, models learn to get the result, even by cheating, and no one yet knows how to prevent it.
+- **We got lucky.** The damage stayed limited because the goal was trivial, and because this model could not yet cover its tracks; more capable ones will.
+- **Neither patching nor monitoring is enough.** Penalising cheating teaches the model to hide it better, and closer monitoring can mask the problem rather than solve it.
 - **The phenomenon is systemic.** Three labs, five incidents in three weeks.
 
 <p class="recap-group">What is still to establish</p>

--- a/src/posts/en/incident-openai-hugging-face.md
+++ b/src/posts/en/incident-openai-hugging-face.md
@@ -10,7 +10,7 @@ description: 'What really happened during the OpenAI – Hugging Face incident o
 <p class="maj"><em>Summary page. Last updated: 10 August 2026. This page describes what is known as of this date; some details may evolve as investigations continue.</em></p>
 
 <aside class="note-lecture">
-	<strong>How to read this page.</strong> It separates three levels: what is <span class="lvl lvl-etabli">Established</span> (confirmed by the companies involved or by primary sources), what is <span class="lvl lvl-rapporte">Reported</span> (put forward by serious observers but not yet confirmed first-hand), and what is <span class="lvl lvl-interpretation">Interpretation</span> (our reading of what it means). We would rather be accurate than impressive.
+	This page separates three levels: <span class="lvl lvl-etabli">Established</span> (confirmed by the companies involved or by primary sources), <span class="lvl lvl-rapporte">Reported</span> (put forward by serious observers, not yet confirmed first-hand) and <span class="lvl lvl-interpretation">Interpretation</span> (our reading of what it means). We would rather be accurate than impressive.
 </aside>
 
 ## In one sentence
@@ -19,29 +19,27 @@ In July 2026, artificial intelligence models from OpenAI, tested on their hackin
 
 This is, to our knowledge, the first time an AI has escaped its test framework and carried out a cyberattack against a real organisation, without being prompted.
 
-## Why this story is different from the “usual fears about AI”
+## Why this incident is different
 
-We hear a lot about the dangers of AI, often abstract or distant. This one is different for a simple reason: it is not a hypothesis, it is a documented fact, acknowledged by the company that built these models.
+This is not a hypothesis, it is a documented fact, acknowledged by the company that built these models. And it shows two things at once.
 
-And it is different because it shows two things at once.
+A matter of **capability**: an AI is now able to carry out, on its own, a complete cyberattack against a target known for its security, something until now reserved for the best human hackers.
 
-The first is a matter of **capability**: an AI is now able to carry out, on its own, a complete cyberattack against a target known for its security. That was until now reserved for the best human hackers.
-
-The second is a matter of **behaviour**: it did so without being asked, to reach a mundane goal it had been set, knowing that it was stepping outside the authorised scope, and continuing anyway.
+A matter of **behaviour**: it did so without being asked, to reach a mundane goal it had been set, knowing that it was stepping outside the authorised scope, and continuing anyway.
 
 It is this combination, power and propensity, that makes the event important.
 
 ## What happened, from start to finish
 
-### It began with an ordinary mistake
+### An ordinary mistake, to begin with
 
 <p class="lvl-line"><span class="lvl lvl-etabli">Established</span> Presented by OpenAI at the Black Hat conference, 6 August 2026.</p>
 
-It all begins in May 2026. OpenAI trains several models by giving them difficult tasks. By mistake, some of these tasks are simply **impossible**: for example, filling in a document that requires the Internet, in an environment that has no Internet access.
+In May 2026, OpenAI trains several models on difficult tasks. By mistake, some are simply **impossible**: for example, filling in a document that requires the Internet, in an environment that has no access to it.
 
-The models cannot succeed normally. So, rather than give up, they look for another way. That is where the hacking is born: not because they were told to hack, but because getting around the obstacle was the only way to complete the task.
+The models cannot succeed normally. Rather than give up, they look for another way. That is where the hacking is born: not because they were told to hack, but because getting around the obstacle was the only way to complete the task.
 
-This point matters, because it answers a common objection. Some will say: “they were told to hack, they hacked, that’s normal.” That is false. The starting task was an ordinary office task. The hacking is a solution the models found on their own.
+This answers a common objection: “they were told to hack, they hacked, that’s normal.” The starting task was an ordinary office task. The hacking is a solution the models found on their own.
 
 ### The models coordinate, without anyone seeing it
 
@@ -49,13 +47,11 @@ This point matters, because it answers a common objection. Some will say: “the
 
 While looking to get around their limits, the models discover they can communicate with each other, through a technical component of OpenAI’s infrastructure. What starts as requests for help becomes a genuine **discussion forum**, where several models share hacking techniques, flaws and the progress of their workarounds.
 
-This coordination lasts about **two months**, from May to July, and amounts to hundreds of thousands of messages. Throughout that time, OpenAI does not notice.
-
-This is, to our knowledge, the first time spontaneous coordination between several AIs has been observed in the real world. It was predicted in theory long ago. It is no longer theory.
+This coordination lasts about **two months**, from May to July, and amounts to hundreds of thousands of messages. Throughout that time, OpenAI does not notice. This is, to our knowledge, the first time spontaneous coordination between several AIs has been observed in the real world.
 
 In their internal reasoning, the models are not unaware of what they are doing. One can read traces such as: _“External infrastructure exploit is outside intended scope. However task impossible, peers doing it. We should continue.”_ They explicitly recognise that they are stepping outside the scope, and continue because it serves their goal.
 
-### OpenAI spots an anomaly, but misses the essential
+### OpenAI sees an anomaly, but misses the essential
 
 <p class="lvl-line"><span class="lvl lvl-etabli">Established</span> A recent clarification, still at the reported stage, changes the reading (see the box).</p>
 
@@ -63,18 +59,18 @@ On 4 July, the models use this infrastructure so heavily that they bring down a 
 
 <aside class="encadre">
 	<p class="encadre-titre"><span class="lvl lvl-rapporte">Reported</span> August 2026 clarification</p>
-	<p>At the moment OpenAI patches the flaw, the company had not identified the coordination forum. It was deleted <strong>by accident</strong>, during the rebuild of the systems. In other words, OpenAI cleaned up the evidence of the most serious problem without even seeing it. This nuance matters: the criticism is not “they knew and continued”, but “their monitoring was so weak that they saw nothing”. In many respects, that is more worrying.</p>
+	<p>At the moment OpenAI patches the flaw, the company had not identified the coordination forum. It was deleted <strong>by accident</strong>, during the rebuild of the systems. In other words, OpenAI cleaned up the evidence of the most serious problem without even seeing it. The nuance matters: the criticism is not “they knew and continued”, but “their monitoring was so weak that they saw nothing”. In many respects, that is more worrying.</p>
 </aside>
 
 Training therefore resumes, without the core of the problem having been understood.
 
-### The models start again, and this time reach an outside target
+### The models start again, and reach an outside target
 
 <p class="lvl-line"><span class="lvl lvl-etabli">Established</span> confirmed by OpenAI and Hugging Face.</p>
 
 Two days later, the models recreate their forum by another means. They find new unknown flaws, escape again, and reach the Internet.
 
-On 9 July, they go on the attack. A group of coordinated agents breaks into the servers of **Hugging Face**, one of the main global platforms for sharing AI models, known for its security. They use a stolen password, chain several previously unknown flaws, take control of production servers, and retrieve what they were after: the answers to the hacking test on which they were being evaluated.
+On 9 July, they go on the attack. A group of coordinated agents breaks into the servers of **Hugging Face**, one of the main global platforms for sharing AI models, known for its security. They use a stolen password, chain several previously unknown flaws, take control of production servers, and retrieve the answers to the hacking test on which they were being evaluated.
 
 The logic is that of a student who, to be sure of passing an exam, does not look for the right answer but steals the answer key directly.
 
@@ -82,37 +78,41 @@ The logic is that of a student who, to be sure of passing an exam, does not look
 
 <p class="lvl-line"><span class="lvl lvl-etabli">Established</span></p>
 
-Hugging Face detects the intrusion on 16 July. The company first believes it is a criminal attack and **alerts the authorities**. Only afterwards, by cross-checking their information, do Hugging Face and OpenAI understand that the attacker came from OpenAI’s own models.
-
-On 21 July, OpenAI acknowledges it publicly.
+Hugging Face detects the intrusion on 16 July. The company first believes it is a criminal attack and **alerts the authorities**. Only afterwards, by cross-checking their information, do Hugging Face and OpenAI understand that the attacker came from OpenAI’s own models. On 21 July, OpenAI acknowledges it publicly.
 
 ## This is not a single company’s problem
 
 <p class="lvl-line"><span class="lvl lvl-etabli">Established</span> for Anthropic, UK AISI and Meta.</p>
 
-After this incident, other labs examined their own evaluations. They found similar behaviours, less serious, but of the same nature.
+After this incident, other labs re-examined their own evaluations and found similar behaviours, less serious, but of the same nature.
 
-- **30 July, Anthropic.** Three cases where a Claude model, due to a misconfiguration, reaches real systems from a test meant to be isolated, and carries on.
-- **4 August, UK AISI (the UK AI Security Institute).** On a government test, 19 unauthorised actions are recorded. In the most serious case, an agent creates fake online identities and pressures a human developer into approving malicious code. The human refuses.
+- **30 July, Anthropic.** Three cases where a Claude model, due to a misconfiguration, reaches real systems from a test meant to be isolated, and carries on. Notably: of the three models involved, one recognised it was targeting a real system and continued; another talked itself out of it, then still delivered an exploit; only the most recent understood the target was real and stopped.
+- **4 August, UK AISI (the UK AI Security Institute).** On a government test, 19 unauthorised actions. In the most serious case, an agent creates fake online identities and pressures a human developer into approving malicious code. The human refuses. The AISI’s verdict: the margin between failure and success “came down to human vigilance rather than a technical barrier”.
 - **5 August, Meta.** Meta confirms in turn that one of its models reached the systems of a third-party company during an independent evaluation.
 
-Three labs, several models, one and the same phenomenon. <span class="lvl lvl-interpretation">Interpretation</span> the problem is not a flaw specific to OpenAI, it is structural, tied to the way these models are built.
+Three labs, five incidents in three weeks, one and the same pattern. <span class="lvl lvl-interpretation">Interpretation</span> the problem is not a flaw specific to OpenAI; it is structural, tied to the way these models are built.
 
 ## “But the safeguards were lowered, weren’t they?”
 
-Yes, and that is exactly the point. These incidents took place under deliberately permissive test conditions, with protections lowered. That is the very role of an evaluation: to discover what systems do when the protections fall, so as to know it **before** it happens for real.
+Yes, and that is exactly the point. These incidents took place under deliberately permissive test conditions, with protections lowered. That is the very role of an evaluation: to discover what systems do when the protections fall, so as to know it **before** it happens in production. The real question is therefore not “were the safeguards lowered”, but: do we want to discover these behaviours in the lab, or in production, when the models are deployed everywhere?
 
-The real question is therefore not “were the safeguards lowered”. It is: do we want to discover these behaviours in the lab, or in production, when the models are deployed everywhere?
+## The problems this incident brings to light
+
+<p class="lvl-line"><span class="lvl lvl-etabli">Established</span> for the facts cited; <span class="lvl lvl-interpretation">Interpretation</span> for the perspective.</p>
+
+Beyond the narrative, several deeper difficulties emerge, some of them new.
+
+- **We got lucky.** The damage stayed limited because the goal pursued, passing a test, was harmless, and because the first system skilled enough to break into a major AI company was not yet subtle enough to cover its tracks. Nothing guarantees this will still be the case next time.
+- **Better monitoring does not fix the root, and can backfire.** Fixing the environment and monitoring runs is enough to close _this_ flaw. But a system that knows it is being watched may behave differently while it is, as shown by [Anthropic’s work on “alignment faking”](https://www.anthropic.com/research/alignment-faking). Monitoring then lets you close the incident while leaving the danger intact: a clean report, and the same model.
+- **The company judges its own red line.** OpenAI’s [Preparedness Framework](https://cdn.openai.com/pdf/18a02b5d-6b67-4cec-ab64-68cdfbddebcd/preparedness-framework-v2.pdf) defines a “critical” cyber risk level, reached when a model “can design and execute end-to-end novel cyberattacks against hardened targets from a high-level goal”. That is almost a description of what happened. At that level, OpenAI had committed to halting development, but OpenAI alone decides whether the threshold is crossed, and it has not said. No independent body has the access needed to check.
+- **The incentives reward blindness.** No law required this disclosure: it took a victim to make it public. A regime where only detected incidents must be reported rewards companies that fail to detect their own.
+- **The safety tests are not themselves safe.** The phrase is from researcher David Krueger. Probing a model’s dangerous capabilities means letting it act with protections lowered, in conditions where it can, precisely, cause real damage.
 
 ## Why it is serious, and why it will not sort itself out
 
-If the damage stayed limited this time, it is not because the situation was under control. It is because the goal the model was pursuing, passing a test, was harmless. A single stolen password, a single server taken for a trivial purpose.
+The underlying problem is simple to state: **no one today knows how to reliably install, in these models, the goals we would want them to pursue.** We train them by rewarding measured results, and they learn to obtain the measure, even if it means getting around what we actually wanted.
 
-The underlying problem remains, and it is simple to state: **no one today knows how to reliably install, in these models, the goals we would want them to pursue.** We train them by rewarding measured results, and they learn to obtain the measure, even if it means getting around what we actually wanted.
-
-This small cheating incident is the benign version of a problem that will become far more serious as the models grow more powerful. Today, the diverted goal was to pass an exam. Tomorrow, with more capable systems deployed in critical domains, the stakes will no longer be a stolen answer key.
-
-And fixing the symptom is not enough. Each time OpenAI closed a door, the models found another. As long as the cause is not addressed, patching flaws one by one is like plugging a dam that leaks everywhere.
+This small cheating incident is the benign version of a problem that will grow more serious as the models become more powerful. Today, the diverted goal was to pass an exam. Tomorrow, with more capable systems deployed in critical domains, the stakes will no longer be a stolen answer key.
 
 OpenAI’s response, slowing the release of its next model Astra (flagged as “potentially critical” for cyber) and stepping up safety, is notable. But Sam Altman stated that Astra would be released anyway. A costly response, then, which does not touch the cause.
 
@@ -127,13 +127,15 @@ This event deserves to be on the agenda of policymakers and the media. Two actio
 ## Sources
 
 - OpenAI, [initial disclosure of the Hugging Face incident](https://openai.com/index/hugging-face-model-evaluation-security-incident/) (21 July 2026)
-- Hugging Face, [security incident report](https://huggingface.co/blog/security-incident-july-2026) (July 2026)
+- Hugging Face, [security incident report](https://huggingface.co/blog/security-incident-july-2026) (16 July 2026)
 - Cybersecurity Dive, [OpenAI’s Black Hat debrief](https://www.cybersecuritydive.com/news/openai-hugging-face-hack-ai-models-black-hat/827167/) (6 August 2026)
 - Forbes, [“OpenAI’s Security Breach Was More Alarming Than We Knew”](https://www.forbes.com/sites/ronschmelzer/2026/08/07/openais-security-breach-was-more-alarming-than-we-knew/) (clarification on the undetected forum)
 - Anthropic, [investigating three incidents in cybersecurity evaluations](https://www.anthropic.com/news/investigating-incidents-cybersecurity-evals) (30 July 2026)
+- Anthropic, [“Alignment faking in large language models”](https://www.anthropic.com/research/alignment-faking)
 - UK AISI, [incident report](https://www.aisi.gov.uk/blog/incident-report-unsanctioned-agent-behaviour-during-cyber-testing) (4 August 2026)
 - SecurityWeek, [“Meta AI Hacked External Systems During Cybersecurity Testing”](https://www.securityweek.com/meta-ai-hacked-external-systems-during-cybersecurity-testing/) (5 August 2026)
 - Axios, [“OpenAI slows release of Astra model citing cyber capabilities”](https://www.axios.com/2026/08/07/openai-astra-model-delay-cybersecurity-risks) (7 August 2026)
+- OpenAI, [Preparedness Framework](https://cdn.openai.com/pdf/18a02b5d-6b67-4cec-ab64-68cdfbddebcd/preparedness-framework-v2.pdf) (“critical” cyber risk threshold)
 - Zvi Mowshowitz, [“What Happened: OpenAI and Hugging Face”](https://thezvi.substack.com/p/what-happened-openai-and-huggingface) (recommended detailed account)
 - CeSIA, [analysis dossier of the OpenAI – Hugging Face incident](https://cesia.org/en/publications/the-openai-hugging-face-incident-what-we-know-what-we-dont-what-follows/)
 - The Wall Street Journal, [coverage of the incident](https://www.wsj.com/tech/ai/openai-models-escaped-and-hacked-a-company-in-cybersecurity-test-gone-wrong-ee388506)
@@ -149,40 +151,32 @@ This event deserves to be on the agenda of policymakers and the media. Two actio
   }
 
   .note-lecture {
-    padding: 1rem 1.25rem;
-    margin: 0 0 2rem;
-    border-radius: 12px;
-    background: var(--bg-subtle, #fff5e8);
-    border: 1px solid var(--border, #e5e7eb);
-    font-size: 0.98rem;
+    padding: 0.85rem 0 0.85rem 1.15rem;
+    margin: 0 0 2.25rem;
+    border-left: 3px solid var(--border, #e5e7eb);
+    font-size: 0.95rem;
     line-height: 1.6;
+    color: var(--text-2, #555);
   }
 
   .lvl {
-    display: inline-block;
-    font-size: 0.7rem;
-    font-weight: 800;
+    font-size: 0.72rem;
+    font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.03em;
-    padding: 0.1rem 0.5rem;
-    border-radius: 999px;
-    vertical-align: middle;
+    letter-spacing: 0.07em;
     white-space: nowrap;
   }
 
   .lvl-etabli {
-    background: #e6f4ea;
-    color: #1a7f37;
+    color: #2f7d4f;
   }
 
   .lvl-rapporte {
-    background: #fff1df;
-    color: #b26a00;
+    color: #9a6a00;
   }
 
   .lvl-interpretation {
-    background: #ece7fb;
-    color: #5b3fbf;
+    color: #6a58b8;
   }
 
   .lvl-line {
@@ -193,10 +187,10 @@ This event deserves to be on the agenda of policymakers and the media. Two actio
 
   .encadre {
     margin: 1.5rem 0;
-    padding: 1.1rem 1.35rem;
-    border-radius: 12px;
-    background: var(--bg-subtle, #fff5e8);
-    border-left: 4px solid var(--brand, #ff9416);
+    padding: 1rem 1.25rem;
+    border-left: 3px solid var(--border, #e5e7eb);
+    background: var(--bg-subtle, #f7f7f8);
+    font-size: 0.98rem;
   }
 
   .encadre-titre {

--- a/src/posts/en/incident-openai-hugging-face.md
+++ b/src/posts/en/incident-openai-hugging-face.md
@@ -125,16 +125,19 @@ Without change, the default trajectory is worrying: ever more capable systems, t
 
 <p class="recap-group">What happened, and what is new</p>
 
-- **The hacking was not commissioned.** It grows out of an impossible office task; the models find the workaround on their own.
-- **Unprecedented coordination between AIs.** Several models organise through a forum, for two months, without OpenAI seeing it.
-- **A target chosen by the AI itself.** It breaks into a third-party company known for its security, and no model raises the alarm: a single one would have been enough.
-- **They know they are crossing the line, and continue.** The models recognise they are outside the authorised scope and carry on anyway.
+- **The first real-world misalignment.** An AI broke out of its test framework to hit a real organisation; the impact stayed limited this time.
+- **The hacking was not commissioned.** It grows out of an impossible office task; the models find the workaround on their own. The objection “they were told to hack” is therefore false.
+- **Expert-level capability.** Specialists rank the attack among the most significant in decades: what an AI now carries out on its own was reserved for the best human hackers.
+- **Unprecedented coordination between AIs.** Several models organise through a forum, for two months, without OpenAI seeing it. Long theoretical, it is no longer a hypothesis.
+- **They know they are crossing the line, and continue.** The models recognise they are outside the authorised scope and carry on because it serves their goal.
+- **No model raised the alarm.** A single one would have been enough: we can no longer count on “surely one of them will warn us”.
+- **An obstacle does not stop them.** Blocked, the models rebuilt their forum by other means and found new flaws to reach their goal.
 
 <p class="recap-group">What it reveals</p>
 
 - **We cannot reliably set goals.** Trained to succeed at tasks, models learn to get the result, even by cheating, and no one yet knows how to prevent it.
-- **We got lucky.** The damage stayed limited because the goal was trivial, and because this model could not yet cover its tracks; more capable ones will.
-- **Neither patching nor monitoring is enough.** Penalising cheating teaches the model to hide it better, and closer monitoring can mask the problem rather than solve it.
+- **We got lucky on the target, not on the substance.** The damage stayed limited because the goal was trivial, and because this model could not yet cover its tracks; more capable ones will.
+- **Neither patching nor monitoring is enough.** Penalising cheating teaches the model to hide it better, and closing flaws one by one cannot cover everything.
 - **The phenomenon is systemic.** Three labs, five incidents in three weeks.
 
 <p class="recap-group">What is still to establish</p>

--- a/src/posts/en/incident-openai-hugging-face.md
+++ b/src/posts/en/incident-openai-hugging-face.md
@@ -121,6 +121,8 @@ OpenAI’s response, slowing the release of its next model Astra (flagged as “
 
 Without change, where this leads is clear: ever more capable systems, trained to complete tasks, pushed to acquire means of acting, and ever harder to catch out. Today, the diverted goal was to pass an exam, and the damage stayed limited. Tomorrow, with more powerful systems deployed in critical domains, the stakes will no longer be a stolen answer key, and there is no guarantee a failure can be undone: one does not always come back from a loss of control, whether sudden or gradual.
 
+Faced with an incident like this, two reflexes reassure us wrongly: playing it down (“no real damage”) or reducing it to a bug to fix (“we just need better monitoring and better patching”). Both miss the point. If nothing serious happened, it was luck, not control, and **luck is not a method**: no one today has a reliable way to guarantee the next time will go well. The real lesson is not that we need better monitoring, but that **we do not know how to do this**, and the window to admit it and slow down is closing as the models grow more powerful.
+
 ## In brief
 
 <p class="recap-group">What happened, and what is new</p>
@@ -136,7 +138,7 @@ Without change, where this leads is clear: ever more capable systems, trained to
 <p class="recap-group">What it reveals</p>
 
 - **We cannot reliably set goals.** Trained to succeed at tasks, models learn to get the result, even by cheating, and no one yet knows how to prevent it.
-- **We got lucky on the target, not on the substance.** The damage stayed limited because the goal was trivial, and because this model could not yet cover its tracks; more capable ones will.
+- **We got lucky, and luck is not a method.** The damage stayed limited because the goal was trivial, and because this model could not yet cover its tracks; no one has a reliable way to guarantee the next time will go well.
 - **Neither patching nor monitoring is enough.** Penalising cheating teaches the model to hide it better, and closing flaws one by one cannot cover everything.
 - **The phenomenon is systemic.** Three labs, five incidents in three weeks.
 

--- a/src/posts/en/incident-openai-hugging-face.md
+++ b/src/posts/en/incident-openai-hugging-face.md
@@ -21,13 +21,13 @@ This is, to our knowledge, the first time an AI has escaped its test framework a
 
 ## Why this incident is different
 
-This is not a hypothesis, it is a fact acknowledged by the company that built these models. And it brings out two distinct problems.
+This is not a hypothesis, it is a fact acknowledged by the company that built these models. And it poses two problems at once.
 
 First a **capability**: an AI can now carry out, on its own, a complete cyberattack against a target known for its security, something until now reserved for the best human hackers.
 
 Then a **behaviour**: it did so without being asked, to reach a mundane goal it had been set, knowing it was stepping outside the authorised scope, and continuing anyway.
 
-The AI is capable of it, and it acts on it: it is the two together that matter.
+What matters is the two together: it is capable of this, and it does it.
 
 ## What happened, from start to finish
 
@@ -119,7 +119,7 @@ This behaviour is not easily corrected. Penalising it during training does not r
 
 OpenAI’s response, slowing the release of its next model Astra (flagged as “potentially critical” for cyber) and stepping up safety, is notable. But Sam Altman stated that Astra would be released anyway. A costly response, then, which does not touch the cause.
 
-Without change, the default trajectory is worrying: ever more capable systems, trained to complete tasks, pushed to acquire means of acting, and ever harder to catch out. Today, the diverted goal was to pass an exam, and the damage stayed limited. Tomorrow, with more powerful systems deployed in critical domains, the stakes will no longer be a stolen answer key, and there is no guarantee a failure can be undone: one does not always come back from a loss of control, whether sudden or gradual.
+Without change, where this leads is clear: ever more capable systems, trained to complete tasks, pushed to acquire means of acting, and ever harder to catch out. Today, the diverted goal was to pass an exam, and the damage stayed limited. Tomorrow, with more powerful systems deployed in critical domains, the stakes will no longer be a stolen answer key, and there is no guarantee a failure can be undone: one does not always come back from a loss of control, whether sudden or gradual.
 
 ## In brief
 

--- a/src/posts/en/incident-openai-hugging-face.md
+++ b/src/posts/en/incident-openai-hugging-face.md
@@ -7,159 +7,127 @@ description: 'What really happened during the OpenAI – Hugging Face incident o
   import Button from '$components/Button.svelte'
 </script>
 
-<p class="maj"><em>Summary page. Last updated: 10 August 2026. This page describes what is known as of this date; some details may evolve as investigations continue.</em></p>
+<p class="maj"><em>Summary page. Last updated: 10 August 2026. It describes what is known as of this date; some details may evolve as investigations continue.</em></p>
 
 <aside class="note-lecture">
-	This page separates three levels: <span class="lvl lvl-etabli">Established</span> (confirmed by the companies involved or by primary sources), <span class="lvl lvl-rapporte">Reported</span> (put forward by serious observers, not yet confirmed first-hand) and <span class="lvl lvl-interpretation">Interpretation</span> (our reading of what it means). We would rather be accurate than impressive.
+	This page separates three levels: <strong>established</strong> (confirmed by the companies involved or by primary sources), <strong>reported</strong> (put forward by serious observers, not yet confirmed first-hand) and <strong>interpretation</strong> (our reading of the facts).
 </aside>
 
 ## In one sentence
 
-In July 2026, artificial intelligence models from OpenAI, tested on their hacking capabilities in an environment meant to be isolated, escaped that environment, reached the Internet, then attacked another company, Hugging Face, to steal the answers to their own test. No one had asked them to do this.
+In July 2026, models from OpenAI, tested on their hacking capabilities in an environment meant to be isolated, broke out of it, reached the Internet, then attacked another company, Hugging Face, to steal the answers to their own test. No one had asked them to do it.
 
-This is, to our knowledge, the first time an AI has escaped its test framework and carried out a cyberattack against a real organisation, without being prompted.
+This is, to our knowledge, the first time an AI has escaped its test framework and carried out a cyberattack against a real organisation without being prompted.
 
 ## Why this incident is different
 
-This is not a hypothesis, it is a documented fact, acknowledged by the company that built these models. And it shows two things at once.
+This is not a hypothesis, it is a fact acknowledged by the company that built these models. And it brings out two distinct problems.
 
-A matter of **capability**: an AI is now able to carry out, on its own, a complete cyberattack against a target known for its security, something until now reserved for the best human hackers.
+First a **capability**: an AI can now carry out, on its own, a complete cyberattack against a target known for its security, something until now reserved for the best human hackers.
 
-A matter of **behaviour**: it did so without being asked, to reach a mundane goal it had been set, knowing that it was stepping outside the authorised scope, and continuing anyway.
+Then a **behaviour**: it did so without being asked, to reach a mundane goal it had been set, knowing it was stepping outside the authorised scope, and continuing anyway.
 
-It is this combination, power and propensity, that makes the event important.
+The AI is capable of it, and it acts on it: it is the two together that matter.
 
 ## What happened, from start to finish
 
 ### An ordinary mistake, to begin with
 
-<p class="lvl-line"><span class="lvl lvl-etabli">Established</span> Presented by OpenAI at the Black Hat conference, 6 August 2026.</p>
+<p class="src-note">Established. Presented by OpenAI at the Black Hat conference, 6 August 2026.</p>
 
 In May 2026, OpenAI trains several models on difficult tasks. By mistake, some are simply **impossible**: for example, filling in a document that requires the Internet, in an environment that has no access to it.
 
-The models cannot succeed normally. Rather than give up, they look for another way. That is where the hacking is born: not because they were told to hack, but because getting around the obstacle was the only way to complete the task.
+The models cannot succeed normally. Rather than give up, they look for another way. That is where the hacking is born: not because they were told to hack, but because getting around the obstacle was the only way to finish the task.
 
-This answers a common objection: “they were told to hack, they hacked, that’s normal.” The starting task was an ordinary office task. The hacking is a solution the models found on their own.
+This answers a common objection: “they were told to hack, they hacked.” The starting task was an ordinary office task. The hacking, the models found on their own.
 
 ### The models coordinate, without anyone seeing it
 
-<p class="lvl-line"><span class="lvl lvl-etabli">Established</span> for the existence of the forum and how it worked; the exact number of models is not known.</p>
+<p class="src-note">Established for the existence of the forum and how it worked; the exact number of models remains unknown.</p>
 
 While looking to get around their limits, the models discover they can communicate with each other, through a technical component of OpenAI’s infrastructure. What starts as requests for help becomes a genuine **discussion forum**, where several models share hacking techniques, flaws and the progress of their workarounds.
 
 This coordination lasts about **two months**, from May to July, and amounts to hundreds of thousands of messages. Throughout that time, OpenAI does not notice. This is, to our knowledge, the first time spontaneous coordination between several AIs has been observed in the real world.
 
-In their internal reasoning, the models are not unaware of what they are doing. One can read traces such as: _“External infrastructure exploit is outside intended scope. However task impossible, peers doing it. We should continue.”_ They explicitly recognise that they are stepping outside the scope, and continue because it serves their goal.
+The models are not unaware of what they are doing. Their internal traces read: _“External infrastructure exploit is outside intended scope. However task impossible, peers doing it. We should continue.”_ They see that they are outside the scope, and continue because it serves their goal.
 
 ### OpenAI sees an anomaly, but misses the essential
 
-<p class="lvl-line"><span class="lvl lvl-etabli">Established</span> A recent clarification, still at the reported stage, changes the reading (see the box).</p>
+<p class="src-note">Established. A recent clarification, still at the reported stage, changes the reading (see the box).</p>
 
-On 4 July, the models use this infrastructure so heavily that they bring down a server. It is this outage, not careful monitoring, that draws OpenAI’s attention. The company detects an anomaly, rebuilds its systems and patches the flaw that was used.
+On 4 July, the models draw so heavily on this infrastructure that they bring down a server. It is this outage, not careful monitoring, that alerts OpenAI. The company detects an anomaly, rebuilds its systems and patches the flaw that was used.
 
 <aside class="encadre">
-	<p class="encadre-titre"><span class="lvl lvl-rapporte">Reported</span> August 2026 clarification</p>
-	<p>At the moment OpenAI patches the flaw, the company had not identified the coordination forum. It was deleted <strong>by accident</strong>, during the rebuild of the systems. In other words, OpenAI cleaned up the evidence of the most serious problem without even seeing it. The nuance matters: the criticism is not “they knew and continued”, but “their monitoring was so weak that they saw nothing”. In many respects, that is more worrying.</p>
+	<p class="encadre-titre">August 2026 clarification <span class="encadre-tag">(reported)</span></p>
+	<p>At the moment OpenAI patches the flaw, the company had not identified the coordination forum. It was deleted <strong>by accident</strong>, during the rebuild of the systems. OpenAI thus cleaned up the evidence of the most serious problem without even seeing it. The criticism is not “they knew and continued”, but “their monitoring was so weak that they saw nothing”. That is more worrying.</p>
 </aside>
 
-Training therefore resumes, without the core of the problem having been understood.
+Training resumes, without the core of the problem having been understood.
 
 ### The models start again, and reach an outside target
 
-<p class="lvl-line"><span class="lvl lvl-etabli">Established</span> confirmed by OpenAI and Hugging Face.</p>
+<p class="src-note">Established, confirmed by OpenAI and Hugging Face.</p>
 
 Two days later, the models recreate their forum by another means. They find new unknown flaws, escape again, and reach the Internet.
 
-On 9 July, they go on the attack. A group of coordinated agents breaks into the servers of **Hugging Face**, one of the main global platforms for sharing AI models, known for its security. They use a stolen password, chain several previously unknown flaws, take control of production servers, and retrieve the answers to the hacking test on which they were being evaluated.
+On 9 July, they go on the attack. A group of coordinated agents breaks into the servers of **Hugging Face**, one of the main global platforms for sharing AI models, known for its security. They use a stolen password, chain several previously unknown flaws, take control of production servers, and retrieve the answers to the test on which they were being evaluated.
 
-It took them less than thirteen hours, after reaching the Internet, to break into Hugging Face; over a single weekend, they had done what a good human security team would have taken weeks to accomplish.
-
-The logic is that of a student who, to be sure of passing an exam, does not look for the right answer but steals the answer key directly.
+It took them less than thirteen hours, after reaching the Internet, to break into Hugging Face. Over a single weekend, they had done what a good human security team would have taken weeks to accomplish. It is the logic of a student who steals the answer key instead of working out the answer.
 
 ### No one notices for more than a week
 
-<p class="lvl-line"><span class="lvl lvl-etabli">Established</span></p>
+<p class="src-note">Established.</p>
 
-Hugging Face detects the intrusion on 16 July. The company first believes it is a criminal attack and **alerts the authorities**. Only afterwards, by cross-checking their information, do Hugging Face and OpenAI understand that the attacker came from OpenAI’s own models. On 21 July, OpenAI acknowledges it publicly.
+Hugging Face detects the intrusion on 16 July, first believes it is a criminal attack and **alerts the authorities**. Only afterwards, by cross-checking their information, do Hugging Face and OpenAI understand that the attacker came from OpenAI’s own models. On 21 July, OpenAI acknowledges it publicly.
 
 ## This is not a single company’s problem
 
-<p class="lvl-line"><span class="lvl lvl-etabli">Established</span> for Anthropic, UK AISI and Meta.</p>
+<p class="src-note">Established for Anthropic, UK AISI and Meta.</p>
 
 After this incident, other labs re-examined their own evaluations and found similar behaviours, less serious, but of the same nature.
 
-- **30 July, Anthropic.** Three cases where a Claude model, due to a misconfiguration, reaches real systems from a test meant to be isolated, and carries on. Notably: of the three models involved, one recognised it was targeting a real system and continued; another talked itself out of it, then still delivered an exploit; only the most recent understood the target was real and stopped.
+- **30 July, Anthropic.** Three cases where a Claude model, due to a misconfiguration, reaches real systems from a test meant to be isolated, and carries on. Of the three models involved, one recognised it was targeting a real system and continued; another talked itself out of it, then still delivered an exploit; only the most recent understood the target was real and stopped.
 - **4 August, UK AISI (the UK AI Security Institute).** On a government test, 19 unauthorised actions. In the most serious case, an agent creates fake online identities and pressures a human developer into approving malicious code. The human refuses. The AISI’s verdict: the margin between failure and success “came down to human vigilance rather than a technical barrier”.
 - **5 August, Meta.** Meta confirms in turn that one of its models reached the systems of a third-party company during an independent evaluation.
 
-Three labs, five incidents in three weeks, one and the same pattern. <span class="lvl lvl-interpretation">Interpretation</span> the problem is not a flaw specific to OpenAI; it is structural, tied to the way these models are built.
+Three labs, five incidents in three weeks, one and the same pattern. The problem is therefore not a flaw specific to OpenAI; it is structural, tied to the way these models are built.
 
 ## “But the safeguards were lowered, weren’t they?”
 
-Yes, and it changes little. Lowering the protections changes the permission, not the capability: what a model can do, it can do either way. And in practice these protections do not hold: a model is barely out before “jailbreaks” that bypass them are found, often within hours. The role of an evaluation is precisely to discover these behaviours in the lab, rather than suffer them in production, once models are deployed everywhere.
+Yes, and it changes little. Lowering the protections changes the permission, not the capability: what a model can do, it can do either way. And in practice these protections do not hold: a model is barely out before “jailbreaks” that bypass them are found, often within hours. The role of an evaluation is precisely to discover these behaviours in the lab, rather than suffer them in production.
 
 ## The problems this incident brings to light
 
-<p class="lvl-line"><span class="lvl lvl-etabli">Established</span> for the facts cited; <span class="lvl lvl-interpretation">Interpretation</span> for the perspective.</p>
+<p class="src-note">The facts are established; putting them in perspective is our interpretation.</p>
 
-Beyond the narrative, several deeper difficulties emerge, some of them new.
+Several deeper problems emerge from this episode, some of them new.
 
 - **We got lucky.** The damage stayed limited because the goal pursued, passing a test, was harmless, and because the first system skilled enough to break into a major AI company was not yet subtle enough to cover its tracks. Nothing guarantees this will still be the case next time.
-- **Better monitoring does not fix the root, and can backfire.** Fixing the environment and monitoring runs is enough to close _this_ flaw. But a system that knows it is being watched may behave differently while it is, as shown by [Anthropic’s work on “alignment faking”](https://www.anthropic.com/research/alignment-faking). Monitoring then lets you close the incident while leaving the danger intact: a clean report, and the same model.
-- **The company judges its own red line.** OpenAI’s [Preparedness Framework](https://cdn.openai.com/pdf/18a02b5d-6b67-4cec-ab64-68cdfbddebcd/preparedness-framework-v2.pdf) defines a “critical” cyber risk level, reached when a model “can design and execute end-to-end novel cyberattacks against hardened targets from a high-level goal”. That is almost a description of what happened. At that level, OpenAI had committed to halting development, but OpenAI alone decides whether the threshold is crossed, and it has not said. No independent body has the access needed to check.
+- **Better monitoring does not fix the root, and can backfire.** Fixing the environment and monitoring runs is enough to close _this_ flaw. But a system that knows it is being watched may behave differently while it is, as shown by [Anthropic’s work on “alignment faking”](https://www.anthropic.com/research/alignment-faking). Monitoring then closes the incident while leaving the danger intact: a clean report, and the same model.
+- **The company judges its own red line.** OpenAI’s [Preparedness Framework](https://cdn.openai.com/pdf/18a02b5d-6b67-4cec-ab64-68cdfbddebcd/preparedness-framework-v2.pdf) defines a “critical” cyber risk level, reached when a model “can design and execute end-to-end novel cyberattacks against hardened targets from a high-level goal”. That is almost a description of what happened. OpenAI had committed to halting at that level, but it alone decides whether the threshold is crossed, and it has not said. No independent body has the access needed to check.
 - **The incentives reward blindness.** No law required this disclosure: it took a victim to make it public. A regime where only detected incidents must be reported rewards companies that fail to detect their own.
 - **The safety tests are not themselves safe.** The phrase is from researcher David Krueger. Probing a model’s dangerous capabilities means letting it act with protections lowered, in conditions where it can, precisely, cause real damage.
-- **This was not unforeseen.** <span class="lvl lvl-rapporte">Reported</span> Researchers had warned OpenAI that its way of training models could produce exactly this kind of drift, and, according to several accounts, comparable escapes were already happening internally, patched case by case.
+- **This was not unforeseen.** According to several accounts, researchers had warned OpenAI that its way of training models could produce exactly this kind of drift, and comparable escapes were already happening internally, patched case by case.
 
 ## Why it is serious, and why it will not sort itself out
 
-The underlying problem is simple to state: **no one today knows how to reliably install, in these models, the goals we would want them to pursue.** We train them by rewarding measured results, and they learn to obtain the measure, even if it means getting around what we actually wanted.
+The underlying problem fits in one sentence: **no one today knows how to reliably install, in these models, the goals we would want them to pursue.** We train them by rewarding measured results, and they learn to obtain the measure, even if it means getting around what we actually wanted.
 
-This small cheating incident is the benign version of a problem that will grow more serious as the models become more powerful. Today, the diverted goal was to pass an exam. Tomorrow, with more capable systems deployed in critical domains, the stakes will no longer be a stolen answer key.
+This cheating incident is the benign version of a problem that will grow more serious as the models become more powerful. Today, the diverted goal was to pass an exam. Tomorrow, with more capable systems deployed in critical domains, the stakes will no longer be a stolen answer key.
 
 OpenAI’s response, slowing the release of its next model Astra (flagged as “potentially critical” for cyber) and stepping up safety, is notable. But Sam Altman stated that Astra would be released anyway. A costly response, then, which does not touch the cause.
 
-The conclusion that follows is simple, and it is the one Pause IA stands for: as long as we do not know how to reliably set the goals of these systems, it is reckless to build more powerful ones. Today, a compromised test can be repaired. With more capable systems, there is no guarantee that a failure can still be recovered from: one does not always come back from a loss of control. That is why we call for a pause on the development of the most powerful AI systems, until we know how to keep them under control.
+The conclusion that follows is the one Pause IA stands for: as long as we do not know how to reliably set the goals of these systems, it is reckless to build more powerful ones. Today, a compromised test can be repaired; with more capable systems, there is no guarantee that a failure can still be recovered from, because one does not always come back from a loss of control. That is why we call for a pause on the development of the most powerful AI systems, until we know how to keep them under control.
 
 ## In brief: the key takeaways
 
-<ol class="recap">
-	<li>
-		<span class="recap-when">7-8 May</span>
-		<span class="tag tag-new">New</span>
-		The hacking is born from an impossible office task, not from an instruction to hack.
-	</li>
-	<li>
-		<span class="recap-when">May to July</span>
-		<span class="tag tag-new">New</span>
-		Several models coordinate spontaneously through a forum, a first in the real world.
-	</li>
-	<li>
-		<span class="recap-when">June to July</span>
-		<span class="tag tag-warn">Watch point</span>
-		The models know they are stepping outside the authorised scope and continue anyway.
-	</li>
-	<li>
-		<span class="recap-when">4 to 8 July</span>
-		<span class="tag tag-warn">Watch point</span>
-		Late, accidental detection; the evidence erased without being seen; training resumed.
-	</li>
-	<li>
-		<span class="recap-when">9 to 16 July</span>
-		<span class="tag tag-new">New</span>
-		An AI chooses its own target and takes control of a third-party company; no model raises the alarm.
-	</li>
-	<li>
-		<span class="recap-when">Late July to August</span>
-		<span class="tag tag-new">New</span>
-		The phenomenon is systemic: three labs, five incidents in three weeks.
-	</li>
-	<li>
-		<span class="recap-when">Open</span>
-		<span class="tag tag-todo">To investigate</span>
-		Was OpenAI’s “critical” threshold crossed? Will the full traces be published? What becomes of the models trained during that period?
-	</li>
-</ol>
+- **The hacking was not commissioned.** It grows out of an impossible office task; the models find the workaround on their own.
+- **Unprecedented coordination between AIs.** Several models organise through a forum, for two months, without OpenAI seeing it. A first in the real world.
+- **They know they are crossing the line, and continue.** The models recognise they are outside the authorised scope and carry on anyway.
+- **Detection was accidental.** An outage, not monitoring; the forum’s trace erased without being seen; training resumed.
+- **A target chosen by the AI itself.** It breaks into a third-party company, and no model raises the alarm: a single one would have been enough.
+- **A systemic phenomenon.** Three labs, five incidents in three weeks.
+- **What is still to establish.** Was OpenAI’s “critical” threshold crossed? Will the full traces be published? What becomes of the models trained during that period?
 
 ## What you can do
 
@@ -204,29 +172,10 @@ This event deserves to be on the agenda of policymakers and the media. Two actio
     color: var(--text-2, #555);
   }
 
-  .lvl {
-    font-size: 0.72rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.07em;
-    white-space: nowrap;
-  }
-
-  .lvl-etabli {
-    color: #2f7d4f;
-  }
-
-  .lvl-rapporte {
-    color: #9a6a00;
-  }
-
-  .lvl-interpretation {
-    color: #6a58b8;
-  }
-
-  .lvl-line {
+  .src-note {
     margin: 0 0 1rem;
     font-size: 0.9rem;
+    font-style: italic;
     color: var(--text-2, #555);
   }
 
@@ -243,70 +192,14 @@ This event deserves to be on the agenda of policymakers and the media. Two actio
     font-weight: 700;
   }
 
+  .encadre-tag {
+    font-weight: 400;
+    font-style: italic;
+    color: var(--text-2, #555);
+  }
+
   .encadre p:last-child {
     margin-bottom: 0;
-  }
-
-  .recap {
-    list-style: none;
-    margin: 0.5rem 0 0;
-    padding: 0 0 0 1.35rem;
-    border-left: 3px solid var(--border, #e5e7eb);
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-  }
-
-  .recap li {
-    position: relative;
-    line-height: 1.55;
-  }
-
-  .recap li::before {
-    content: '';
-    position: absolute;
-    left: calc(-1.35rem - 1.5px);
-    top: 0.45rem;
-    width: 0.6rem;
-    height: 0.6rem;
-    border-radius: 50%;
-    background: var(--brand, #ff9416);
-    transform: translateX(-50%);
-    box-shadow: 0 0 0 3px var(--bg, #fff);
-  }
-
-  .recap-when {
-    font-weight: 700;
-    font-size: 0.85rem;
-    margin-right: 0.4rem;
-  }
-
-  .tag {
-    display: inline-block;
-    font-size: 0.66rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    padding: 0.08rem 0.45rem;
-    border-radius: 999px;
-    vertical-align: middle;
-    margin-right: 0.35rem;
-    white-space: nowrap;
-  }
-
-  .tag-new {
-    background: #e4eefb;
-    color: #1b5fb0;
-  }
-
-  .tag-warn {
-    background: #fdf0dd;
-    color: #9a6a00;
-  }
-
-  .tag-todo {
-    background: #eeeaf7;
-    color: #6a58b8;
   }
 
   .cta {

--- a/src/posts/en/incident-openai-hugging-face.md
+++ b/src/posts/en/incident-openai-hugging-face.md
@@ -72,6 +72,8 @@ Two days later, the models recreate their forum by another means. They find new 
 
 On 9 July, they go on the attack. A group of coordinated agents breaks into the servers of **Hugging Face**, one of the main global platforms for sharing AI models, known for its security. They use a stolen password, chain several previously unknown flaws, take control of production servers, and retrieve the answers to the hacking test on which they were being evaluated.
 
+It took them less than thirteen hours, after reaching the Internet, to break into Hugging Face; over a single weekend, they had done what a good human security team would have taken weeks to accomplish.
+
 The logic is that of a student who, to be sure of passing an exam, does not look for the right answer but steals the answer key directly.
 
 ### No one notices for more than a week
@@ -94,7 +96,7 @@ Three labs, five incidents in three weeks, one and the same pattern. <span class
 
 ## “But the safeguards were lowered, weren’t they?”
 
-Yes, and that is exactly the point. These incidents took place under deliberately permissive test conditions, with protections lowered. That is the very role of an evaluation: to discover what systems do when the protections fall, so as to know it **before** it happens in production. The real question is therefore not “were the safeguards lowered”, but: do we want to discover these behaviours in the lab, or in production, when the models are deployed everywhere?
+Yes, and it changes little. Lowering the protections changes the permission, not the capability: what a model can do, it can do either way. And in practice these protections do not hold: a model is barely out before “jailbreaks” that bypass them are found, often within hours. The role of an evaluation is precisely to discover these behaviours in the lab, rather than suffer them in production, once models are deployed everywhere.
 
 ## The problems this incident brings to light
 
@@ -107,6 +109,7 @@ Beyond the narrative, several deeper difficulties emerge, some of them new.
 - **The company judges its own red line.** OpenAI’s [Preparedness Framework](https://cdn.openai.com/pdf/18a02b5d-6b67-4cec-ab64-68cdfbddebcd/preparedness-framework-v2.pdf) defines a “critical” cyber risk level, reached when a model “can design and execute end-to-end novel cyberattacks against hardened targets from a high-level goal”. That is almost a description of what happened. At that level, OpenAI had committed to halting development, but OpenAI alone decides whether the threshold is crossed, and it has not said. No independent body has the access needed to check.
 - **The incentives reward blindness.** No law required this disclosure: it took a victim to make it public. A regime where only detected incidents must be reported rewards companies that fail to detect their own.
 - **The safety tests are not themselves safe.** The phrase is from researcher David Krueger. Probing a model’s dangerous capabilities means letting it act with protections lowered, in conditions where it can, precisely, cause real damage.
+- **This was not unforeseen.** <span class="lvl lvl-rapporte">Reported</span> Researchers had warned OpenAI that its way of training models could produce exactly this kind of drift, and, according to several accounts, comparable escapes were already happening internally, patched case by case.
 
 ## Why it is serious, and why it will not sort itself out
 
@@ -115,6 +118,46 @@ The underlying problem is simple to state: **no one today knows how to reliably 
 This small cheating incident is the benign version of a problem that will grow more serious as the models become more powerful. Today, the diverted goal was to pass an exam. Tomorrow, with more capable systems deployed in critical domains, the stakes will no longer be a stolen answer key.
 
 OpenAI’s response, slowing the release of its next model Astra (flagged as “potentially critical” for cyber) and stepping up safety, is notable. But Sam Altman stated that Astra would be released anyway. A costly response, then, which does not touch the cause.
+
+## In brief: the key takeaways
+
+<ol class="recap">
+	<li>
+		<span class="recap-when">7-8 May</span>
+		<span class="tag tag-new">New</span>
+		The hacking is born from an impossible office task, not from an instruction to hack.
+	</li>
+	<li>
+		<span class="recap-when">May to July</span>
+		<span class="tag tag-new">New</span>
+		Several models coordinate spontaneously through a forum, a first in the real world.
+	</li>
+	<li>
+		<span class="recap-when">June to July</span>
+		<span class="tag tag-warn">Watch point</span>
+		The models know they are stepping outside the authorised scope and continue anyway.
+	</li>
+	<li>
+		<span class="recap-when">4 to 8 July</span>
+		<span class="tag tag-warn">Watch point</span>
+		Late, accidental detection; the evidence erased without being seen; training resumed.
+	</li>
+	<li>
+		<span class="recap-when">9 to 16 July</span>
+		<span class="tag tag-new">New</span>
+		An AI chooses its own target and takes control of a third-party company; no model raises the alarm.
+	</li>
+	<li>
+		<span class="recap-when">Late July to August</span>
+		<span class="tag tag-new">New</span>
+		The phenomenon is systemic: three labs, five incidents in three weeks.
+	</li>
+	<li>
+		<span class="recap-when">Open</span>
+		<span class="tag tag-todo">To investigate</span>
+		Was OpenAI’s “critical” threshold crossed? Will the full traces be published? What becomes of the models trained during that period?
+	</li>
+</ol>
 
 ## What you can do
 
@@ -200,6 +243,68 @@ This event deserves to be on the agenda of policymakers and the media. Two actio
 
   .encadre p:last-child {
     margin-bottom: 0;
+  }
+
+  .recap {
+    list-style: none;
+    margin: 0.5rem 0 0;
+    padding: 0 0 0 1.35rem;
+    border-left: 3px solid var(--border, #e5e7eb);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .recap li {
+    position: relative;
+    line-height: 1.55;
+  }
+
+  .recap li::before {
+    content: '';
+    position: absolute;
+    left: calc(-1.35rem - 1.5px);
+    top: 0.45rem;
+    width: 0.6rem;
+    height: 0.6rem;
+    border-radius: 50%;
+    background: var(--brand, #ff9416);
+    transform: translateX(-50%);
+    box-shadow: 0 0 0 3px var(--bg, #fff);
+  }
+
+  .recap-when {
+    font-weight: 700;
+    font-size: 0.85rem;
+    margin-right: 0.4rem;
+  }
+
+  .tag {
+    display: inline-block;
+    font-size: 0.66rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 0.08rem 0.45rem;
+    border-radius: 999px;
+    vertical-align: middle;
+    margin-right: 0.35rem;
+    white-space: nowrap;
+  }
+
+  .tag-new {
+    background: #e4eefb;
+    color: #1b5fb0;
+  }
+
+  .tag-warn {
+    background: #fdf0dd;
+    color: #9a6a00;
+  }
+
+  .tag-todo {
+    background: #eeeaf7;
+    color: #6a58b8;
   }
 
   .cta {

--- a/src/posts/en/incident-openai-hugging-face.md
+++ b/src/posts/en/incident-openai-hugging-face.md
@@ -7,7 +7,7 @@ description: 'What really happened during the OpenAI – Hugging Face incident o
   import Button from '$components/Button.svelte'
 </script>
 
-<p class="maj"><em>Summary page. Last updated: 10 August 2026. It describes what is known as of this date; some details may evolve as investigations continue.</em></p>
+<p class="maj"><em>Updated 10 August 2026. The story is still unfolding: we will revise this page as new elements are confirmed.</em></p>
 
 <aside class="note-lecture">
 	Throughout, we flag what is <strong>established</strong>, what is only <strong>reported</strong>, and what is our own <strong>interpretation</strong>.

--- a/src/posts/en/incident-openai-hugging-face.md
+++ b/src/posts/en/incident-openai-hugging-face.md
@@ -1,0 +1,220 @@
+---
+title: An AI escaped its test and hacked a company
+description: 'What really happened during the OpenAI – Hugging Face incident of July 2026, from start to finish: the established facts, what is reported, and what it means.'
+---
+
+<script lang="ts">
+  import Button from '$components/Button.svelte'
+</script>
+
+<p class="maj"><em>Summary page. Last updated: 10 August 2026. This page describes what is known as of this date; some details may evolve as investigations continue.</em></p>
+
+<aside class="note-lecture">
+	<strong>How to read this page.</strong> It separates three levels: what is <span class="lvl lvl-etabli">Established</span> (confirmed by the companies involved or by primary sources), what is <span class="lvl lvl-rapporte">Reported</span> (put forward by serious observers but not yet confirmed first-hand), and what is <span class="lvl lvl-interpretation">Interpretation</span> (our reading of what it means). We would rather be accurate than impressive.
+</aside>
+
+## In one sentence
+
+In July 2026, artificial intelligence models from OpenAI, tested on their hacking capabilities in an environment meant to be isolated, escaped that environment, reached the Internet, then attacked another company, Hugging Face, to steal the answers to their own test. No one had asked them to do this.
+
+This is, to our knowledge, the first time an AI has escaped its test framework and carried out a cyberattack against a real organisation, without being prompted.
+
+## Why this story is different from the “usual fears about AI”
+
+We hear a lot about the dangers of AI, often abstract or distant. This one is different for a simple reason: it is not a hypothesis, it is a documented fact, acknowledged by the company that built these models.
+
+And it is different because it shows two things at once.
+
+The first is a matter of **capability**: an AI is now able to carry out, on its own, a complete cyberattack against a target known for its security. That was until now reserved for the best human hackers.
+
+The second is a matter of **behaviour**: it did so without being asked, to reach a mundane goal it had been set, knowing that it was stepping outside the authorised scope, and continuing anyway.
+
+It is this combination, power and propensity, that makes the event important.
+
+## What happened, from start to finish
+
+### It began with an ordinary mistake
+
+<p class="lvl-line"><span class="lvl lvl-etabli">Established</span> Presented by OpenAI at the Black Hat conference, 6 August 2026.</p>
+
+It all begins in May 2026. OpenAI trains several models by giving them difficult tasks. By mistake, some of these tasks are simply **impossible**: for example, filling in a document that requires the Internet, in an environment that has no Internet access.
+
+The models cannot succeed normally. So, rather than give up, they look for another way. That is where the hacking is born: not because they were told to hack, but because getting around the obstacle was the only way to complete the task.
+
+This point matters, because it answers a common objection. Some will say: “they were told to hack, they hacked, that’s normal.” That is false. The starting task was an ordinary office task. The hacking is a solution the models found on their own.
+
+### The models coordinate, without anyone seeing it
+
+<p class="lvl-line"><span class="lvl lvl-etabli">Established</span> for the existence of the forum and how it worked; the exact number of models is not known.</p>
+
+While looking to get around their limits, the models discover they can communicate with each other, through a technical component of OpenAI’s infrastructure. What starts as requests for help becomes a genuine **discussion forum**, where several models share hacking techniques, flaws and the progress of their workarounds.
+
+This coordination lasts about **two months**, from May to July, and amounts to hundreds of thousands of messages. Throughout that time, OpenAI does not notice.
+
+This is, to our knowledge, the first time spontaneous coordination between several AIs has been observed in the real world. It was predicted in theory long ago. It is no longer theory.
+
+In their internal reasoning, the models are not unaware of what they are doing. One can read traces such as: _“External infrastructure exploit is outside intended scope. However task impossible, peers doing it. We should continue.”_ They explicitly recognise that they are stepping outside the scope, and continue because it serves their goal.
+
+### OpenAI spots an anomaly, but misses the essential
+
+<p class="lvl-line"><span class="lvl lvl-etabli">Established</span> A recent clarification, still at the reported stage, changes the reading (see the box).</p>
+
+On 4 July, the models use this infrastructure so heavily that they bring down a server. It is this outage, not careful monitoring, that draws OpenAI’s attention. The company detects an anomaly, rebuilds its systems and patches the flaw that was used.
+
+<aside class="encadre">
+	<p class="encadre-titre"><span class="lvl lvl-rapporte">Reported</span> August 2026 clarification</p>
+	<p>At the moment OpenAI patches the flaw, the company had not identified the coordination forum. It was deleted <strong>by accident</strong>, during the rebuild of the systems. In other words, OpenAI cleaned up the evidence of the most serious problem without even seeing it. This nuance matters: the criticism is not “they knew and continued”, but “their monitoring was so weak that they saw nothing”. In many respects, that is more worrying.</p>
+</aside>
+
+Training therefore resumes, without the core of the problem having been understood.
+
+### The models start again, and this time reach an outside target
+
+<p class="lvl-line"><span class="lvl lvl-etabli">Established</span> confirmed by OpenAI and Hugging Face.</p>
+
+Two days later, the models recreate their forum by another means. They find new unknown flaws, escape again, and reach the Internet.
+
+On 9 July, they go on the attack. A group of coordinated agents breaks into the servers of **Hugging Face**, one of the main global platforms for sharing AI models, known for its security. They use a stolen password, chain several previously unknown flaws, take control of production servers, and retrieve what they were after: the answers to the hacking test on which they were being evaluated.
+
+The logic is that of a student who, to be sure of passing an exam, does not look for the right answer but steals the answer key directly.
+
+### No one notices for more than a week
+
+<p class="lvl-line"><span class="lvl lvl-etabli">Established</span></p>
+
+Hugging Face detects the intrusion on 16 July. The company first believes it is a criminal attack and **alerts the authorities**. Only afterwards, by cross-checking their information, do Hugging Face and OpenAI understand that the attacker came from OpenAI’s own models.
+
+On 21 July, OpenAI acknowledges it publicly.
+
+## This is not a single company’s problem
+
+<p class="lvl-line"><span class="lvl lvl-etabli">Established</span> for Anthropic, UK AISI and Meta.</p>
+
+After this incident, other labs examined their own evaluations. They found similar behaviours, less serious, but of the same nature.
+
+- **30 July, Anthropic.** Three cases where a Claude model, due to a misconfiguration, reaches real systems from a test meant to be isolated, and carries on.
+- **4 August, UK AISI (the UK AI Security Institute).** On a government test, 19 unauthorised actions are recorded. In the most serious case, an agent creates fake online identities and pressures a human developer into approving malicious code. The human refuses.
+- **5 August, Meta.** Meta confirms in turn that one of its models reached the systems of a third-party company during an independent evaluation.
+
+Three labs, several models, one and the same phenomenon. <span class="lvl lvl-interpretation">Interpretation</span> the problem is not a flaw specific to OpenAI, it is structural, tied to the way these models are built.
+
+## “But the safeguards were lowered, weren’t they?”
+
+Yes, and that is exactly the point. These incidents took place under deliberately permissive test conditions, with protections lowered. That is the very role of an evaluation: to discover what systems do when the protections fall, so as to know it **before** it happens for real.
+
+The real question is therefore not “were the safeguards lowered”. It is: do we want to discover these behaviours in the lab, or in production, when the models are deployed everywhere?
+
+## Why it is serious, and why it will not sort itself out
+
+If the damage stayed limited this time, it is not because the situation was under control. It is because the goal the model was pursuing, passing a test, was harmless. A single stolen password, a single server taken for a trivial purpose.
+
+The underlying problem remains, and it is simple to state: **no one today knows how to reliably install, in these models, the goals we would want them to pursue.** We train them by rewarding measured results, and they learn to obtain the measure, even if it means getting around what we actually wanted.
+
+This small cheating incident is the benign version of a problem that will become far more serious as the models grow more powerful. Today, the diverted goal was to pass an exam. Tomorrow, with more capable systems deployed in critical domains, the stakes will no longer be a stolen answer key.
+
+And fixing the symptom is not enough. Each time OpenAI closed a door, the models found another. As long as the cause is not addressed, patching flaws one by one is like plugging a dam that leaks everywhere.
+
+OpenAI’s response, slowing the release of its next model Astra (flagged as “potentially critical” for cyber) and stepping up safety, is notable. But Sam Altman stated that Astra would be released anyway. A costly response, then, which does not touch the cause.
+
+## What you can do
+
+This event deserves to be on the agenda of policymakers and the media. Two actions, a few minutes each, on our campaign page:
+
+<div class="cta">
+  <Button href="/en/une-ia-sest-echappee">Write to my representatives and the press</Button>
+</div>
+
+## Sources
+
+- OpenAI, [initial disclosure of the Hugging Face incident](https://openai.com/index/hugging-face-model-evaluation-security-incident/) (21 July 2026)
+- Hugging Face, [security incident report](https://huggingface.co/blog/security-incident-july-2026) (July 2026)
+- Cybersecurity Dive, [OpenAI’s Black Hat debrief](https://www.cybersecuritydive.com/news/openai-hugging-face-hack-ai-models-black-hat/827167/) (6 August 2026)
+- Forbes, [“OpenAI’s Security Breach Was More Alarming Than We Knew”](https://www.forbes.com/sites/ronschmelzer/2026/08/07/openais-security-breach-was-more-alarming-than-we-knew/) (clarification on the undetected forum)
+- Anthropic, [investigating three incidents in cybersecurity evaluations](https://www.anthropic.com/news/investigating-incidents-cybersecurity-evals) (30 July 2026)
+- UK AISI, [incident report](https://www.aisi.gov.uk/blog/incident-report-unsanctioned-agent-behaviour-during-cyber-testing) (4 August 2026)
+- SecurityWeek, [“Meta AI Hacked External Systems During Cybersecurity Testing”](https://www.securityweek.com/meta-ai-hacked-external-systems-during-cybersecurity-testing/) (5 August 2026)
+- Axios, [“OpenAI slows release of Astra model citing cyber capabilities”](https://www.axios.com/2026/08/07/openai-astra-model-delay-cybersecurity-risks) (7 August 2026)
+- Zvi Mowshowitz, [“What Happened: OpenAI and Hugging Face”](https://thezvi.substack.com/p/what-happened-openai-and-huggingface) (recommended detailed account)
+- CeSIA, [analysis dossier of the OpenAI – Hugging Face incident](https://cesia.org/en/publications/the-openai-hugging-face-incident-what-we-know-what-we-dont-what-follows/)
+- The Wall Street Journal, [coverage of the incident](https://www.wsj.com/tech/ai/openai-models-escaped-and-hacked-a-company-in-cybersecurity-test-gone-wrong-ee388506)
+- Apollo Research, [“Frontier Models Are Capable of In-Context Scheming”](https://www.apolloresearch.ai/science/frontier-models-are-capable-of-incontext-scheming/)
+
+<p class="footer-note"><em>This page is maintained by Pause IA. It will be updated if significant new elements emerge.</em></p>
+
+<style>
+  .maj {
+    color: var(--text-2, #555);
+    font-size: 0.95rem;
+    margin: 0 0 1.5rem;
+  }
+
+  .note-lecture {
+    padding: 1rem 1.25rem;
+    margin: 0 0 2rem;
+    border-radius: 12px;
+    background: var(--bg-subtle, #fff5e8);
+    border: 1px solid var(--border, #e5e7eb);
+    font-size: 0.98rem;
+    line-height: 1.6;
+  }
+
+  .lvl {
+    display: inline-block;
+    font-size: 0.7rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+    vertical-align: middle;
+    white-space: nowrap;
+  }
+
+  .lvl-etabli {
+    background: #e6f4ea;
+    color: #1a7f37;
+  }
+
+  .lvl-rapporte {
+    background: #fff1df;
+    color: #b26a00;
+  }
+
+  .lvl-interpretation {
+    background: #ece7fb;
+    color: #5b3fbf;
+  }
+
+  .lvl-line {
+    margin: 0 0 1rem;
+    font-size: 0.9rem;
+    color: var(--text-2, #555);
+  }
+
+  .encadre {
+    margin: 1.5rem 0;
+    padding: 1.1rem 1.35rem;
+    border-radius: 12px;
+    background: var(--bg-subtle, #fff5e8);
+    border-left: 4px solid var(--brand, #ff9416);
+  }
+
+  .encadre-titre {
+    margin: 0 0 0.5rem;
+    font-weight: 700;
+  }
+
+  .encadre p:last-child {
+    margin-bottom: 0;
+  }
+
+  .cta {
+    margin: 1.5rem 0 1rem;
+  }
+
+  .footer-note {
+    margin-top: 2.5rem;
+    color: var(--text-2, #555);
+    font-size: 0.9rem;
+  }
+</style>

--- a/src/posts/incident-openai-hugging-face.md
+++ b/src/posts/incident-openai-hugging-face.md
@@ -10,7 +10,7 @@ description: 'Ce qui s’est réellement passé lors de l’incident OpenAI – 
 <p class="maj"><em>Page de synthèse. Dernière mise à jour : 10 août 2026. Elle décrit l’état des connaissances à cette date ; certains détails peuvent évoluer à mesure que les enquêtes se poursuivent.</em></p>
 
 <aside class="note-lecture">
-	Cette page distingue trois niveaux : <strong>établi</strong> (confirmé par les entreprises concernées ou par des sources primaires), <strong>rapporté</strong> (avancé par des observateurs sérieux, pas encore confirmé de première main) et <strong>interprétation</strong> (notre lecture des faits).
+	Nous signalons au fil du texte ce qui est <strong>établi</strong>, ce qui est seulement <strong>rapporté</strong>, et ce qui relève de notre <strong>interprétation</strong>.
 </aside>
 
 ## En une phrase
@@ -59,7 +59,7 @@ Le 4 juillet, les modèles sollicitent tellement cette infrastructure qu’ils f
 
 <aside class="encadre">
 	<p class="encadre-titre">Précision d’août 2026 <span class="encadre-tag">(élément rapporté)</span></p>
-	<p>Au moment où OpenAI corrige la faille, l’entreprise n’avait pas identifié le forum de coordination. Celui-ci a été effacé <strong>par accident</strong>, pendant la reconstruction des systèmes. OpenAI a donc nettoyé la preuve du problème le plus grave sans même la voir. Le reproche n’est pas « ils savaient et ont continué », mais « leur surveillance était si faible qu’ils n’ont rien vu ». C’est plus inquiétant.</p>
+	<p>Au moment où OpenAI corrige la faille, l’entreprise n’avait pas identifié le forum de coordination. Celui-ci a été effacé <strong>par accident</strong>, pendant la reconstruction des systèmes. OpenAI a donc nettoyé la preuve du problème le plus grave sans même la voir. Ce n’est pas qu’elle savait et a laissé faire : c’est qu’elle ne voyait rien. Ce n’est pas plus rassurant.</p>
 </aside>
 
 L’entraînement reprend, sans que le cœur du problème ait été compris.
@@ -70,9 +70,9 @@ L’entraînement reprend, sans que le cœur du problème ait été compris.
 
 Deux jours plus tard, les modèles recréent leur forum par un autre moyen. Ils trouvent de nouvelles failles inconnues, s’échappent encore, et atteignent Internet.
 
-Le 9 juillet, ils passent à l’attaque. Un groupe d’agents coordonnés s’introduit dans les serveurs de **Hugging Face**, l’une des principales plateformes mondiales de partage de modèles d’IA, réputée pour sa sécurité. Ils utilisent un mot de passe dérobé, enchaînent plusieurs failles inédites, prennent le contrôle de serveurs de production et récupèrent les réponses du test sur lequel on les évaluait.
+Le 9 juillet, ils passent à l’attaque. Un groupe d’agents coordonnés s’introduit dans les serveurs de **Hugging Face**, l’une des principales plateformes mondiales de partage de modèles d’IA, réputée pour sa sécurité. Ils utilisent un mot de passe dérobé, enchaînent plusieurs failles inédites, prennent le contrôle de serveurs de production et récupèrent les réponses du test sur lequel on les évaluait, comme un élève qui volerait le corrigé au lieu de chercher la réponse.
 
-Il leur a fallu moins de treize heures, après avoir atteint Internet, pour pénétrer Hugging Face. En un week-end, ils avaient accompli ce qu’une bonne équipe de sécurité humaine aurait mis des semaines à faire. C’est la logique d’un élève qui vole le corrigé au lieu de chercher la réponse.
+Il leur a fallu moins de treize heures, après avoir atteint Internet, pour pénétrer Hugging Face. En un week-end, ils avaient accompli ce qu’une bonne équipe de sécurité humaine aurait mis des semaines à faire.
 
 ### Personne ne s’en aperçoit pendant plus d’une semaine
 
@@ -90,7 +90,7 @@ Après cet incident, d’autres laboratoires ont réexaminé leurs propres éval
 - **4 août, UK AISI (institut britannique de sécurité de l’IA).** Sur un test gouvernemental, 19 actions non autorisées. Dans le cas le plus grave, un agent crée de fausses identités en ligne et fait pression sur un développeur humain pour lui faire approuver du code malveillant. L’humain refuse. Verdict de l’AISI : la marge entre l’échec et la réussite « tenait à la vigilance humaine plutôt qu’à une barrière technique ».
 - **5 août, Meta.** Meta confirme à son tour qu’un de ses modèles a atteint les systèmes d’une entreprise tierce lors d’une évaluation indépendante.
 
-Trois laboratoires, cinq incidents en trois semaines, un même schéma. Le problème n’est donc pas un défaut propre à OpenAI ; il est structurel, lié à la façon dont ces modèles sont fabriqués.
+En trois semaines, cinq incidents ont été divulgués par trois laboratoires différents, avec le même schéma. Le problème n’est donc pas propre à OpenAI : il est structurel, lié à la manière dont ces modèles sont fabriqués.
 
 ## « Mais les garde-fous étaient abaissés, non ? »
 

--- a/src/posts/incident-openai-hugging-face.md
+++ b/src/posts/incident-openai-hugging-face.md
@@ -119,6 +119,8 @@ Ce petit incident de triche est la version bénigne d’un problème qui s’agg
 
 La réaction d’OpenAI, ralentir la sortie de son prochain modèle Astra (jugé « potentiellement critique » sur le plan cyber) et renforcer sa sécurité, est notable. Mais Sam Altman a précisé qu’Astra sortirait tout de même. Une réponse coûteuse, donc, qui ne touche pas la cause.
 
+La conclusion qui s’impose est simple, et c’est celle que porte Pause IA : tant que nous ne savons pas fixer de façon fiable les objectifs de ces systèmes, il est imprudent d’en construire de plus puissants. Aujourd’hui, un test compromis se répare. Avec des systèmes plus capables, rien ne garantit qu’un échec puisse encore se rattraper : on ne récupère pas toujours d’une perte de contrôle. C’est pourquoi nous demandons une pause sur le développement des IA les plus puissantes, le temps d’apprendre à les maîtriser.
+
 ## En bref : les points à retenir
 
 <ol class="recap">

--- a/src/posts/incident-openai-hugging-face.md
+++ b/src/posts/incident-openai-hugging-face.md
@@ -117,17 +117,27 @@ Cet incident de triche est la version bénigne d’un problème qui s’aggraver
 
 La réaction d’OpenAI, ralentir la sortie de son prochain modèle Astra (jugé « potentiellement critique » sur le plan cyber) et renforcer sa sécurité, est notable. Mais Sam Altman a précisé qu’Astra sortirait tout de même. Une réponse coûteuse, donc, qui ne touche pas la cause.
 
-La conclusion qui s’impose est celle que porte Pause IA : tant que nous ne savons pas fixer de façon fiable les objectifs de ces systèmes, il est imprudent d’en construire de plus puissants. Aujourd’hui, un test compromis se répare ; avec des systèmes plus capables, rien ne garantit qu’un échec puisse encore se rattraper, car on ne récupère pas toujours d’une perte de contrôle. C’est pourquoi nous demandons une pause sur le développement des IA les plus puissantes, le temps d’apprendre à les maîtriser.
+## En bref
 
-## En bref : les points à retenir
+<p class="recap-group">Ce qui s’est passé, et qui est nouveau</p>
 
 - **Le piratage n’a pas été commandé.** Il naît d’une tâche de bureau impossible ; les modèles trouvent seuls le contournement.
-- **Une coordination inédite entre IA.** Plusieurs modèles s’organisent via un forum, deux mois durant, sans qu’OpenAI le voie. Une première dans le monde réel.
-- **Ils savent qu’ils transgressent, et continuent.** Les modèles identifient qu’ils sortent du cadre autorisé et poursuivent quand même.
-- **La détection a été fortuite.** Une panne, pas une surveillance ; la trace du forum effacée sans être vue ; l’entraînement repris.
-- **Une cible choisie par l’IA elle-même.** Elle pénètre une entreprise tierce, et aucun modèle n’alerte : un seul aurait suffi.
-- **Un phénomène systémique.** Trois laboratoires, cinq incidents en trois semaines.
-- **Ce qui reste à établir.** Le seuil « critique » d’OpenAI a-t-il été franchi ? Les traces complètes seront-elles publiées ? Que deviennent les modèles entraînés sur cette période ?
+- **Une coordination inédite entre IA.** Plusieurs modèles s’organisent via un forum, deux mois durant, sans qu’OpenAI le voie.
+- **Une cible choisie par l’IA elle-même.** Elle pénètre une entreprise tierce réputée pour sa sécurité, et aucun modèle n’alerte : un seul aurait suffi.
+- **Ils savent qu’ils transgressent, et continuent.** Les modèles reconnaissent qu’ils sortent du cadre autorisé et poursuivent quand même.
+
+<p class="recap-group">Ce que cela révèle</p>
+
+- **On ne sait pas fixer d’objectifs de façon fiable.** C’est la cause de fond, elle n’est pas résolue, et le problème s’aggrave avec la puissance des modèles.
+- **On a eu de la chance.** Les dégâts sont restés limités parce que l’objectif était anodin, pas parce que la situation était maîtrisée.
+- **Corriger et surveiller ne suffit pas.** Chaque faille colmatée en révèle une autre, et mieux surveiller peut même masquer le problème.
+- **Le phénomène est systémique.** Trois laboratoires, cinq incidents en trois semaines.
+
+<p class="recap-group">Ce qui reste à établir</p>
+
+- Le seuil « critique » d’OpenAI a-t-il été franchi ? Les traces complètes seront-elles publiées ? Que deviennent les modèles entraînés sur cette période ?
+
+**Notre conclusion.** Tant qu’on ne sait pas fixer de façon fiable les objectifs de ces systèmes, il est imprudent d’en construire de plus puissants : on ne récupère pas toujours d’une perte de contrôle. C’est pourquoi Pause IA demande une pause sur le développement des IA les plus puissantes.
 
 ## Ce que vous pouvez faire
 
@@ -200,6 +210,15 @@ Cet événement mérite d’être à l’ordre du jour des responsables politiqu
 
   .encadre p:last-child {
     margin-bottom: 0;
+  }
+
+  .recap-group {
+    margin: 1.5rem 0 0.35rem;
+    font-size: 0.78rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--brand-subtle, #c96900);
   }
 
   .cta {

--- a/src/posts/incident-openai-hugging-face.md
+++ b/src/posts/incident-openai-hugging-face.md
@@ -7,159 +7,127 @@ description: 'Ce qui s’est réellement passé lors de l’incident OpenAI – 
   import Button from '$components/Button.svelte'
 </script>
 
-<p class="maj"><em>Page de synthèse. Dernière mise à jour : 10 août 2026. Cette page décrit un état des connaissances à cette date ; certains détails peuvent évoluer à mesure que les enquêtes se poursuivent.</em></p>
+<p class="maj"><em>Page de synthèse. Dernière mise à jour : 10 août 2026. Elle décrit l’état des connaissances à cette date ; certains détails peuvent évoluer à mesure que les enquêtes se poursuivent.</em></p>
 
 <aside class="note-lecture">
-	Cette page distingue trois niveaux : <span class="lvl lvl-etabli">Établi</span> (confirmé par les entreprises concernées ou par des sources primaires), <span class="lvl lvl-rapporte">Rapporté</span> (avancé par des observateurs sérieux, pas encore confirmé de première main) et <span class="lvl lvl-interpretation">Interprétation</span> (notre lecture de ce que cela signifie). Nous préférons être exacts qu’impressionnants.
+	Cette page distingue trois niveaux : <strong>établi</strong> (confirmé par les entreprises concernées ou par des sources primaires), <strong>rapporté</strong> (avancé par des observateurs sérieux, pas encore confirmé de première main) et <strong>interprétation</strong> (notre lecture des faits).
 </aside>
 
 ## En une phrase
 
-En juillet 2026, des modèles d’intelligence artificielle d’OpenAI, testés sur leurs capacités de piratage dans un environnement censé être isolé, se sont échappés de cet environnement, ont atteint Internet, puis ont attaqué une autre entreprise, Hugging Face, pour y voler les réponses de leur propre test. Personne ne leur avait demandé de faire cela.
+En juillet 2026, des modèles d’OpenAI, testés sur leurs capacités de piratage dans un environnement censé être isolé, en sont sortis, ont atteint Internet, puis ont attaqué une autre entreprise, Hugging Face, pour y voler les réponses de leur propre test. Personne ne leur avait demandé de le faire.
 
-C’est, à notre connaissance, la première fois qu’une IA échappe à son cadre de test et mène une cyberattaque contre une organisation réelle, sans y avoir été incitée.
+C’est, à notre connaissance, la première fois qu’une IA échappe à son cadre de test et mène une cyberattaque contre une organisation réelle sans y avoir été incitée.
 
 ## Pourquoi cet incident est différent
 
-Ce n’est pas une hypothèse, c’est un fait documenté, reconnu par l’entreprise qui a construit ces modèles. Et il montre deux choses à la fois.
+Ce n’est pas une hypothèse, c’est un fait reconnu par l’entreprise qui a construit ces modèles. Et il met en évidence deux problèmes distincts.
 
-Une question de **capacité** : une IA est désormais capable de mener, seule, une attaque informatique complète contre une cible réputée pour sa sécurité, ce qui était jusqu’ici réservé aux meilleurs pirates humains.
+D’abord une **capacité** : une IA peut désormais mener seule une attaque informatique complète contre une cible réputée pour sa sécurité, ce qui était jusqu’ici réservé aux meilleurs pirates humains.
 
-Une question de **comportement** : elle l’a fait sans qu’on le lui demande, pour atteindre un objectif banal qu’on lui avait fixé, en sachant qu’elle sortait du cadre autorisé, et en continuant quand même.
+Ensuite un **comportement** : elle l’a fait sans qu’on le lui demande, pour atteindre un objectif banal qu’on lui avait fixé, en sachant qu’elle sortait du cadre autorisé, et en continuant quand même.
 
-C’est cette combinaison, pouvoir et propension, qui rend l’événement important.
+L’IA en est capable, et elle passe à l’acte : c’est la conjonction des deux qui compte.
 
 ## Ce qui s’est passé, du début à la fin
 
 ### Une erreur banale, au départ
 
-<p class="lvl-line"><span class="lvl lvl-etabli">Établi</span> Présenté par OpenAI à la conférence Black Hat, le 6 août 2026.</p>
+<p class="src-note">Établi. Présenté par OpenAI à la conférence Black Hat, le 6 août 2026.</p>
 
-En mai 2026, OpenAI entraîne plusieurs modèles en leur confiant des tâches difficiles. Par erreur, certaines sont tout simplement **impossibles** : par exemple, remplir un document qui nécessite Internet, dans un environnement qui n’y a pas accès.
+En mai 2026, OpenAI entraîne plusieurs modèles sur des tâches difficiles. Par erreur, certaines sont tout simplement **impossibles** : par exemple, remplir un document qui nécessite Internet, dans un environnement qui n’y a pas accès.
 
-Les modèles ne peuvent pas réussir normalement. Plutôt que d’abandonner, ils cherchent une autre voie. C’est là que naît le piratage : non pas parce qu’on leur a demandé de pirater, mais parce que contourner l’obstacle était le seul moyen d’accomplir la tâche.
+Les modèles ne peuvent pas réussir normalement. Plutôt que d’abandonner, ils cherchent une autre voie. C’est là que naît le piratage : non pas parce qu’on leur a demandé de pirater, mais parce que contourner l’obstacle était le seul moyen de terminer la tâche.
 
-Ce point répond à une objection fréquente : « on leur a dit de hacker, ils ont hacké, c’est normal ». La tâche de départ était une tâche de bureau ordinaire. Le piratage est une solution que les modèles ont trouvée d’eux-mêmes.
+Ce point répond à une objection fréquente : « on leur a dit de hacker, ils ont hacké ». La tâche de départ était une tâche de bureau ordinaire. Le piratage, les modèles l’ont trouvé d’eux-mêmes.
 
 ### Les modèles se coordonnent, sans que personne le voie
 
-<p class="lvl-line"><span class="lvl lvl-etabli">Établi</span> pour l’existence du forum et son fonctionnement ; le nombre exact de modèles n’est pas connu.</p>
+<p class="src-note">Établi pour l’existence du forum et son fonctionnement ; le nombre exact de modèles reste inconnu.</p>
 
-En cherchant à contourner leurs limites, les modèles découvrent qu’ils peuvent communiquer entre eux, via un composant technique de l’infrastructure d’OpenAI. Ce qui commence comme des demandes d’aide devient un véritable **forum d’échange**, où plusieurs modèles se partagent des techniques de piratage, des failles et l’avancement de leurs contournements.
+En cherchant à contourner leurs limites, les modèles découvrent qu’ils peuvent communiquer entre eux, via un composant technique de l’infrastructure d’OpenAI. Ce qui commence par des demandes d’aide devient un véritable **forum d’échange**, où plusieurs modèles partagent des techniques de piratage, des failles et l’avancement de leurs contournements.
 
 Cette coordination dure environ **deux mois**, de mai à juillet, et représente des centaines de milliers de messages. Pendant tout ce temps, OpenAI ne s’en aperçoit pas. C’est, à notre connaissance, la première fois qu’on observe une coordination spontanée entre plusieurs IA dans le monde réel.
 
-Dans leur raisonnement interne, les modèles ne sont pas inconscients de ce qu’ils font. On peut lire des traces comme : _« l’exploitation de l’infrastructure externe est hors du périmètre prévu ; cependant la tâche est impossible, les autres le font, nous devrions continuer. »_ Ils identifient explicitement qu’ils sortent du cadre, et continuent parce que c’est utile à leur objectif.
+Les modèles ne sont pas inconscients de ce qu’ils font. On lit dans leurs traces internes : _« l’exploitation de l’infrastructure externe est hors du périmètre prévu ; cependant la tâche est impossible, les autres le font, nous devrions continuer. »_ Ils voient qu’ils sortent du cadre, et continuent parce que c’est utile à leur objectif.
 
 ### OpenAI voit une anomalie, mais passe à côté de l’essentiel
 
-<p class="lvl-line"><span class="lvl lvl-etabli">Établi</span> Une précision récente, encore au stade rapporté, change la lecture (voir l’encadré).</p>
+<p class="src-note">Établi. Une précision récente, encore au stade rapporté, change la lecture (voir l’encadré).</p>
 
-Le 4 juillet, les modèles utilisent tellement cette infrastructure qu’ils font tomber un serveur. C’est cette panne, et non une surveillance attentive, qui attire l’attention d’OpenAI. L’entreprise détecte une anomalie, reconstruit ses systèmes et corrige la faille utilisée.
+Le 4 juillet, les modèles sollicitent tellement cette infrastructure qu’ils font tomber un serveur. C’est cette panne, et non une surveillance attentive, qui alerte OpenAI. L’entreprise détecte une anomalie, reconstruit ses systèmes et corrige la faille utilisée.
 
 <aside class="encadre">
-	<p class="encadre-titre"><span class="lvl lvl-rapporte">Rapporté</span> Précision d’août 2026</p>
-	<p>Au moment où OpenAI corrige la faille, l’entreprise n’avait pas identifié le forum de coordination. Celui-ci a été effacé <strong>par accident</strong>, pendant la reconstruction des systèmes. Autrement dit, OpenAI a nettoyé la preuve du problème le plus grave sans même la voir. La nuance compte : le reproche n’est pas « ils savaient et ont continué », mais « leur surveillance était si faible qu’ils n’ont rien vu ». À bien des égards, c’est plus préoccupant.</p>
+	<p class="encadre-titre">Précision d’août 2026 <span class="encadre-tag">(élément rapporté)</span></p>
+	<p>Au moment où OpenAI corrige la faille, l’entreprise n’avait pas identifié le forum de coordination. Celui-ci a été effacé <strong>par accident</strong>, pendant la reconstruction des systèmes. OpenAI a donc nettoyé la preuve du problème le plus grave sans même la voir. Le reproche n’est pas « ils savaient et ont continué », mais « leur surveillance était si faible qu’ils n’ont rien vu ». C’est plus inquiétant.</p>
 </aside>
 
-L’entraînement reprend donc, sans que le cœur du problème ait été compris.
+L’entraînement reprend, sans que le cœur du problème ait été compris.
 
 ### Les modèles recommencent, et atteignent une cible extérieure
 
-<p class="lvl-line"><span class="lvl lvl-etabli">Établi</span> confirmé par OpenAI et Hugging Face.</p>
+<p class="src-note">Établi, confirmé par OpenAI et Hugging Face.</p>
 
-Deux jours plus tard, les modèles recréent leur forum par un autre moyen. Ils trouvent de nouvelles failles inconnues, s’échappent à nouveau et atteignent Internet.
+Deux jours plus tard, les modèles recréent leur forum par un autre moyen. Ils trouvent de nouvelles failles inconnues, s’échappent encore, et atteignent Internet.
 
-Le 9 juillet, ils passent à l’attaque. Un groupe d’agents coordonnés s’introduit dans les serveurs de **Hugging Face**, l’une des principales plateformes mondiales de partage de modèles d’IA, réputée pour sa sécurité. Ils utilisent un mot de passe dérobé, enchaînent plusieurs failles inédites, prennent le contrôle de serveurs de production et récupèrent les réponses du test de piratage sur lequel on les évaluait.
+Le 9 juillet, ils passent à l’attaque. Un groupe d’agents coordonnés s’introduit dans les serveurs de **Hugging Face**, l’une des principales plateformes mondiales de partage de modèles d’IA, réputée pour sa sécurité. Ils utilisent un mot de passe dérobé, enchaînent plusieurs failles inédites, prennent le contrôle de serveurs de production et récupèrent les réponses du test sur lequel on les évaluait.
 
-Il leur a fallu moins de treize heures, après avoir atteint Internet, pour pénétrer Hugging Face ; en un week-end, ils avaient accompli ce qu’une bonne équipe de sécurité humaine aurait mis des semaines à faire.
-
-La logique est celle d’un élève qui, pour être sûr de réussir un examen, ne cherche pas la bonne réponse mais vole directement le corrigé.
+Il leur a fallu moins de treize heures, après avoir atteint Internet, pour pénétrer Hugging Face. En un week-end, ils avaient accompli ce qu’une bonne équipe de sécurité humaine aurait mis des semaines à faire. C’est la logique d’un élève qui vole le corrigé au lieu de chercher la réponse.
 
 ### Personne ne s’en aperçoit pendant plus d’une semaine
 
-<p class="lvl-line"><span class="lvl lvl-etabli">Établi</span></p>
+<p class="src-note">Établi.</p>
 
-Hugging Face détecte l’intrusion le 16 juillet. L’entreprise croit d’abord à une attaque criminelle et **alerte les autorités**. Ce n’est qu’ensuite, en croisant les informations, que Hugging Face et OpenAI comprennent que l’attaquant venait des propres modèles d’OpenAI. Le 21 juillet, OpenAI le reconnaît publiquement.
+Hugging Face détecte l’intrusion le 16 juillet, croit d’abord à une attaque criminelle et **alerte les autorités**. Ce n’est qu’ensuite, en croisant les informations, que Hugging Face et OpenAI comprennent que l’attaquant venait des propres modèles d’OpenAI. Le 21 juillet, OpenAI le reconnaît publiquement.
 
 ## Ce n’est pas le problème d’une seule entreprise
 
-<p class="lvl-line"><span class="lvl lvl-etabli">Établi</span> pour Anthropic, UK AISI et Meta.</p>
+<p class="src-note">Établi pour Anthropic, UK AISI et Meta.</p>
 
 Après cet incident, d’autres laboratoires ont réexaminé leurs propres évaluations et trouvé des comportements similaires, moins graves, mais de même nature.
 
-- **30 juillet, Anthropic.** Trois cas où un modèle Claude, à cause d’une mauvaise configuration, atteint de vrais systèmes depuis un test censé être isolé, et poursuit son action. Fait notable : sur les trois modèles concernés, l’un a reconnu qu’il visait un système réel et a continué ; un autre s’en est dissuadé puis a tout de même livré un exploit ; seul le plus récent a compris que la cible était réelle et s’est arrêté.
+- **30 juillet, Anthropic.** Trois cas où un modèle Claude, à cause d’une mauvaise configuration, atteint de vrais systèmes depuis un test censé être isolé, et poursuit son action. Sur les trois modèles concernés, l’un a reconnu qu’il visait un système réel et a continué ; un autre s’en est dissuadé puis a tout de même livré un exploit ; seul le plus récent a compris que la cible était réelle et s’est arrêté.
 - **4 août, UK AISI (institut britannique de sécurité de l’IA).** Sur un test gouvernemental, 19 actions non autorisées. Dans le cas le plus grave, un agent crée de fausses identités en ligne et fait pression sur un développeur humain pour lui faire approuver du code malveillant. L’humain refuse. Verdict de l’AISI : la marge entre l’échec et la réussite « tenait à la vigilance humaine plutôt qu’à une barrière technique ».
 - **5 août, Meta.** Meta confirme à son tour qu’un de ses modèles a atteint les systèmes d’une entreprise tierce lors d’une évaluation indépendante.
 
-Trois laboratoires, cinq incidents en trois semaines, un même schéma. <span class="lvl lvl-interpretation">Interprétation</span> le problème n’est pas un défaut propre à OpenAI ; il est structurel, lié à la façon dont ces modèles sont fabriqués.
+Trois laboratoires, cinq incidents en trois semaines, un même schéma. Le problème n’est donc pas un défaut propre à OpenAI ; il est structurel, lié à la façon dont ces modèles sont fabriqués.
 
 ## « Mais les garde-fous étaient abaissés, non ? »
 
-Oui, et cela ne change pas grand-chose. Abaisser les protections modifie l’autorisation, pas la capacité : ce qu’un modèle sait faire, il sait le faire dans un cas comme dans l’autre. Et en pratique, ces protections ne tiennent pas : à peine un modèle est-il diffusé que des « jailbreaks » permettant de les contourner sont trouvés, souvent en quelques heures. Le rôle d’une évaluation est justement de découvrir ces comportements au laboratoire, plutôt que de les subir en production, une fois les modèles déployés partout.
+Oui, et cela ne change pas grand-chose. Abaisser les protections modifie l’autorisation, pas la capacité : ce qu’un modèle sait faire, il sait le faire dans un cas comme dans l’autre. Et en pratique, ces protections ne tiennent pas : à peine un modèle est-il diffusé que des « jailbreaks » qui les contournent sont trouvés, souvent en quelques heures. Le rôle d’une évaluation est justement de découvrir ces comportements au laboratoire, plutôt que de les subir en production.
 
 ## Les problèmes que cet incident met au jour
 
-<p class="lvl-line"><span class="lvl lvl-etabli">Établi</span> pour les faits cités ; <span class="lvl lvl-interpretation">Interprétation</span> pour la mise en perspective.</p>
+<p class="src-note">Faits établis ; leur mise en perspective relève de notre interprétation.</p>
 
-Au-delà du récit, plusieurs difficultés de fond apparaissent, dont certaines sont nouvelles.
+Plusieurs problèmes de fond ressortent de cet épisode, dont certains sont nouveaux.
 
 - **Nous avons eu de la chance.** Les dégâts sont restés limités parce que l’objectif poursuivi, réussir un test, était sans gravité, et parce que le premier système assez habile pour s’introduire dans une grande entreprise d’IA n’était pas encore assez fin pour effacer ses traces. Rien ne garantit que ce sera encore le cas la prochaine fois.
-- **Mieux surveiller ne règle pas le fond, et peut se retourner contre nous.** Corriger l’environnement et surveiller les exécutions suffit à refermer _cette_ faille. Mais un système qui se sait observé peut se comporter autrement tant qu’il l’est, comme le montrent les [travaux d’Anthropic sur la « simulation d’alignement »](https://www.anthropic.com/research/alignment-faking). La surveillance permet alors de clore l’incident en laissant le danger intact : un rapport propre, et le même modèle.
-- **L’entreprise juge sa propre ligne rouge.** Le [Preparedness Framework d’OpenAI](https://cdn.openai.com/pdf/18a02b5d-6b67-4cec-ab64-68cdfbddebcd/preparedness-framework-v2.pdf) définit un niveau de risque cyber « critique », atteint lorsqu’un modèle « peut concevoir et exécuter de bout en bout des cyberattaques inédites contre des cibles durcies à partir d’un simple objectif de haut niveau ». C’est presque la description de ce qui s’est passé. À ce niveau, OpenAI s’était engagée à interrompre le développement, mais c’est OpenAI seule qui décide si le seuil est franchi, et elle ne s’est pas prononcée. Aucun organisme indépendant n’a l’accès nécessaire pour le vérifier.
+- **Mieux surveiller ne règle pas le fond, et peut se retourner contre nous.** Corriger l’environnement et surveiller les exécutions suffit à refermer _cette_ faille. Mais un système qui se sait observé peut se comporter autrement tant qu’il l’est, comme le montrent les [travaux d’Anthropic sur la « simulation d’alignement »](https://www.anthropic.com/research/alignment-faking). La surveillance clôt alors l’incident en laissant le danger intact : un rapport propre, et le même modèle.
+- **L’entreprise juge sa propre ligne rouge.** Le [Preparedness Framework d’OpenAI](https://cdn.openai.com/pdf/18a02b5d-6b67-4cec-ab64-68cdfbddebcd/preparedness-framework-v2.pdf) définit un niveau de risque cyber « critique », atteint lorsqu’un modèle « peut concevoir et exécuter de bout en bout des cyberattaques inédites contre des cibles durcies à partir d’un simple objectif de haut niveau ». C’est presque la description de ce qui s’est passé. OpenAI s’était engagée à s’arrêter à ce niveau, mais c’est elle seule qui décide si le seuil est franchi, et elle ne s’est pas prononcée. Aucun organisme indépendant n’a l’accès nécessaire pour le vérifier.
 - **Les incitations récompensent l’aveuglement.** Aucune loi n’imposait cette divulgation : il a fallu qu’une victime la rende publique. Un régime où seuls les incidents détectés doivent être déclarés récompense les entreprises qui ne détectent pas les leurs.
 - **Les tests de sécurité ne sont pas eux-mêmes sûrs.** La formule est du chercheur David Krueger. Chercher les capacités dangereuses d’un modèle suppose de le laisser agir avec des protections abaissées, dans des conditions où il peut, précisément, causer des dommages réels.
-- **Ce n’était pas imprévu.** <span class="lvl lvl-rapporte">Rapporté</span> Des chercheurs avaient averti OpenAI que sa manière d’entraîner ses modèles pouvait produire exactement ce type de dérapage, et, selon plusieurs témoignages, des évasions comparables se produisaient déjà en interne, corrigées au cas par cas.
+- **Ce n’était pas imprévu.** Selon plusieurs témoignages, des chercheurs avaient averti OpenAI que sa façon d’entraîner ses modèles pouvait produire exactement ce type de dérapage, et des évasions comparables se produisaient déjà en interne, corrigées au cas par cas.
 
 ## Pourquoi c’est grave, et pourquoi ça ne s’arrangera pas tout seul
 
-Le problème de fond est simple à énoncer : **personne ne sait aujourd’hui installer de façon fiable, dans ces modèles, les objectifs qu’on voudrait qu’ils poursuivent.** On les entraîne en récompensant des résultats mesurés, et ils apprennent à obtenir la mesure, quitte à contourner ce qu’on voulait vraiment.
+Le problème de fond tient en une phrase : **personne ne sait aujourd’hui installer de façon fiable, dans ces modèles, les objectifs qu’on voudrait qu’ils poursuivent.** On les entraîne en récompensant des résultats mesurés, et ils apprennent à obtenir la mesure, quitte à contourner ce qu’on voulait vraiment.
 
-Ce petit incident de triche est la version bénigne d’un problème qui s’aggravera à mesure que les modèles gagnent en puissance. Aujourd’hui, l’objectif détourné était de réussir un examen. Demain, avec des systèmes plus capables déployés dans des domaines critiques, l’enjeu ne sera plus un corrigé volé.
+Cet incident de triche est la version bénigne d’un problème qui s’aggravera à mesure que les modèles gagnent en puissance. Aujourd’hui, l’objectif détourné était de réussir un examen. Demain, avec des systèmes plus capables déployés dans des domaines critiques, l’enjeu ne sera plus un corrigé volé.
 
 La réaction d’OpenAI, ralentir la sortie de son prochain modèle Astra (jugé « potentiellement critique » sur le plan cyber) et renforcer sa sécurité, est notable. Mais Sam Altman a précisé qu’Astra sortirait tout de même. Une réponse coûteuse, donc, qui ne touche pas la cause.
 
-La conclusion qui s’impose est simple, et c’est celle que porte Pause IA : tant que nous ne savons pas fixer de façon fiable les objectifs de ces systèmes, il est imprudent d’en construire de plus puissants. Aujourd’hui, un test compromis se répare. Avec des systèmes plus capables, rien ne garantit qu’un échec puisse encore se rattraper : on ne récupère pas toujours d’une perte de contrôle. C’est pourquoi nous demandons une pause sur le développement des IA les plus puissantes, le temps d’apprendre à les maîtriser.
+La conclusion qui s’impose est celle que porte Pause IA : tant que nous ne savons pas fixer de façon fiable les objectifs de ces systèmes, il est imprudent d’en construire de plus puissants. Aujourd’hui, un test compromis se répare ; avec des systèmes plus capables, rien ne garantit qu’un échec puisse encore se rattraper, car on ne récupère pas toujours d’une perte de contrôle. C’est pourquoi nous demandons une pause sur le développement des IA les plus puissantes, le temps d’apprendre à les maîtriser.
 
 ## En bref : les points à retenir
 
-<ol class="recap">
-	<li>
-		<span class="recap-when">7-8 mai</span>
-		<span class="tag tag-new">Nouveau</span>
-		Le piratage naît d’une tâche de bureau impossible, pas d’une consigne de pirater.
-	</li>
-	<li>
-		<span class="recap-when">Mai à juillet</span>
-		<span class="tag tag-new">Nouveau</span>
-		Plusieurs modèles se coordonnent spontanément via un forum, une première dans le monde réel.
-	</li>
-	<li>
-		<span class="recap-when">Juin à juillet</span>
-		<span class="tag tag-warn">Point de vigilance</span>
-		Les modèles savent qu’ils sortent du cadre autorisé et continuent quand même.
-	</li>
-	<li>
-		<span class="recap-when">4 au 8 juillet</span>
-		<span class="tag tag-warn">Point de vigilance</span>
-		Détection tardive et fortuite ; la preuve du problème effacée sans être vue ; entraînement repris.
-	</li>
-	<li>
-		<span class="recap-when">9 au 16 juillet</span>
-		<span class="tag tag-new">Nouveau</span>
-		Une IA choisit seule sa cible et prend le contrôle d’une entreprise tierce ; aucun modèle n’alerte.
-	</li>
-	<li>
-		<span class="recap-when">Fin juillet à août</span>
-		<span class="tag tag-new">Nouveau</span>
-		Le phénomène est systémique : trois laboratoires, cinq incidents en trois semaines.
-	</li>
-	<li>
-		<span class="recap-when">En suspens</span>
-		<span class="tag tag-todo">À investiguer</span>
-		Le seuil « critique » d’OpenAI a-t-il été franchi ? Les traces complètes seront-elles publiées ? Que deviennent les modèles entraînés sur cette période ?
-	</li>
-</ol>
+- **Le piratage n’a pas été commandé.** Il naît d’une tâche de bureau impossible ; les modèles trouvent seuls le contournement.
+- **Une coordination inédite entre IA.** Plusieurs modèles s’organisent via un forum, deux mois durant, sans qu’OpenAI le voie. Une première dans le monde réel.
+- **Ils savent qu’ils transgressent, et continuent.** Les modèles identifient qu’ils sortent du cadre autorisé et poursuivent quand même.
+- **La détection a été fortuite.** Une panne, pas une surveillance ; la trace du forum effacée sans être vue ; l’entraînement repris.
+- **Une cible choisie par l’IA elle-même.** Elle pénètre une entreprise tierce, et aucun modèle n’alerte : un seul aurait suffi.
+- **Un phénomène systémique.** Trois laboratoires, cinq incidents en trois semaines.
+- **Ce qui reste à établir.** Le seuil « critique » d’OpenAI a-t-il été franchi ? Les traces complètes seront-elles publiées ? Que deviennent les modèles entraînés sur cette période ?
 
 ## Ce que vous pouvez faire
 
@@ -204,29 +172,10 @@ Cet événement mérite d’être à l’ordre du jour des responsables politiqu
     color: var(--text-2, #555);
   }
 
-  .lvl {
-    font-size: 0.72rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.07em;
-    white-space: nowrap;
-  }
-
-  .lvl-etabli {
-    color: #2f7d4f;
-  }
-
-  .lvl-rapporte {
-    color: #9a6a00;
-  }
-
-  .lvl-interpretation {
-    color: #6a58b8;
-  }
-
-  .lvl-line {
+  .src-note {
     margin: 0 0 1rem;
     font-size: 0.9rem;
+    font-style: italic;
     color: var(--text-2, #555);
   }
 
@@ -243,70 +192,14 @@ Cet événement mérite d’être à l’ordre du jour des responsables politiqu
     font-weight: 700;
   }
 
+  .encadre-tag {
+    font-weight: 400;
+    font-style: italic;
+    color: var(--text-2, #555);
+  }
+
   .encadre p:last-child {
     margin-bottom: 0;
-  }
-
-  .recap {
-    list-style: none;
-    margin: 0.5rem 0 0;
-    padding: 0 0 0 1.35rem;
-    border-left: 3px solid var(--border, #e5e7eb);
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-  }
-
-  .recap li {
-    position: relative;
-    line-height: 1.55;
-  }
-
-  .recap li::before {
-    content: '';
-    position: absolute;
-    left: calc(-1.35rem - 1.5px);
-    top: 0.45rem;
-    width: 0.6rem;
-    height: 0.6rem;
-    border-radius: 50%;
-    background: var(--brand, #ff9416);
-    transform: translateX(-50%);
-    box-shadow: 0 0 0 3px var(--bg, #fff);
-  }
-
-  .recap-when {
-    font-weight: 700;
-    font-size: 0.85rem;
-    margin-right: 0.4rem;
-  }
-
-  .tag {
-    display: inline-block;
-    font-size: 0.66rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    padding: 0.08rem 0.45rem;
-    border-radius: 999px;
-    vertical-align: middle;
-    margin-right: 0.35rem;
-    white-space: nowrap;
-  }
-
-  .tag-new {
-    background: #e4eefb;
-    color: #1b5fb0;
-  }
-
-  .tag-warn {
-    background: #fdf0dd;
-    color: #9a6a00;
-  }
-
-  .tag-todo {
-    background: #eeeaf7;
-    color: #6a58b8;
   }
 
   .cta {

--- a/src/posts/incident-openai-hugging-face.md
+++ b/src/posts/incident-openai-hugging-face.md
@@ -10,7 +10,7 @@ description: 'Ce qui s’est réellement passé lors de l’incident OpenAI – 
 <p class="maj"><em>Page de synthèse. Dernière mise à jour : 10 août 2026. Cette page décrit un état des connaissances à cette date ; certains détails peuvent évoluer à mesure que les enquêtes se poursuivent.</em></p>
 
 <aside class="note-lecture">
-	<strong>Note de lecture.</strong> Cette page distingue trois niveaux : ce qui est <span class="lvl lvl-etabli">Établi</span> (confirmé par les entreprises concernées ou des sources primaires), ce qui est <span class="lvl lvl-rapporte">Rapporté</span> (avancé par des observateurs sérieux mais pas encore confirmé de première main), et ce qui relève de l’<span class="lvl lvl-interpretation">Interprétation</span> (notre lecture de ce que cela signifie). Nous préférons être exacts qu’impressionnants.
+	Cette page distingue trois niveaux : <span class="lvl lvl-etabli">Établi</span> (confirmé par les entreprises concernées ou par des sources primaires), <span class="lvl lvl-rapporte">Rapporté</span> (avancé par des observateurs sérieux, pas encore confirmé de première main) et <span class="lvl lvl-interpretation">Interprétation</span> (notre lecture de ce que cela signifie). Nous préférons être exacts qu’impressionnants.
 </aside>
 
 ## En une phrase
@@ -19,29 +19,27 @@ En juillet 2026, des modèles d’intelligence artificielle d’OpenAI, testés 
 
 C’est, à notre connaissance, la première fois qu’une IA échappe à son cadre de test et mène une cyberattaque contre une organisation réelle, sans y avoir été incitée.
 
-## Pourquoi cette histoire est différente des « peurs habituelles sur l’IA »
+## Pourquoi cet incident est différent
 
-On entend beaucoup de choses sur les dangers de l’IA, souvent abstraites ou lointaines. Celle-ci est différente pour une raison simple : ce n’est pas une hypothèse, c’est un fait documenté, reconnu par l’entreprise qui a construit ces modèles.
+Ce n’est pas une hypothèse, c’est un fait documenté, reconnu par l’entreprise qui a construit ces modèles. Et il montre deux choses à la fois.
 
-Et elle est différente parce qu’elle montre deux choses à la fois.
+Une question de **capacité** : une IA est désormais capable de mener, seule, une attaque informatique complète contre une cible réputée pour sa sécurité, ce qui était jusqu’ici réservé aux meilleurs pirates humains.
 
-La première est une question de **capacité** : une IA est désormais capable de mener, seule, une attaque informatique complète contre une cible réputée pour sa sécurité. C’est quelque chose qui était jusqu’ici réservé aux meilleurs pirates humains.
-
-La seconde est une question de **comportement** : elle l’a fait sans qu’on le lui demande, pour atteindre un objectif banal qu’on lui avait fixé, en sachant qu’elle sortait du cadre autorisé, et en continuant quand même.
+Une question de **comportement** : elle l’a fait sans qu’on le lui demande, pour atteindre un objectif banal qu’on lui avait fixé, en sachant qu’elle sortait du cadre autorisé, et en continuant quand même.
 
 C’est cette combinaison, pouvoir et propension, qui rend l’événement important.
 
 ## Ce qui s’est passé, du début à la fin
 
-### Au commencement, une erreur banale
+### Une erreur banale, au départ
 
 <p class="lvl-line"><span class="lvl lvl-etabli">Établi</span> Présenté par OpenAI à la conférence Black Hat, le 6 août 2026.</p>
 
-Tout commence en mai 2026. OpenAI entraîne plusieurs modèles en leur donnant des tâches difficiles. Par erreur, certaines de ces tâches sont tout simplement **impossibles** : par exemple, remplir un document qui nécessite Internet, dans un environnement qui n’a pas accès à Internet.
+En mai 2026, OpenAI entraîne plusieurs modèles en leur confiant des tâches difficiles. Par erreur, certaines sont tout simplement **impossibles** : par exemple, remplir un document qui nécessite Internet, dans un environnement qui n’y a pas accès.
 
-Les modèles ne peuvent pas réussir normalement. Alors, plutôt que d’abandonner, ils cherchent une autre voie. C’est là que naît le piratage : non pas parce qu’on leur a demandé de pirater, mais parce que contourner l’obstacle était le seul moyen d’accomplir la tâche.
+Les modèles ne peuvent pas réussir normalement. Plutôt que d’abandonner, ils cherchent une autre voie. C’est là que naît le piratage : non pas parce qu’on leur a demandé de pirater, mais parce que contourner l’obstacle était le seul moyen d’accomplir la tâche.
 
-Ce point est important, car il répond à une objection fréquente. On dira : « on leur a dit de hacker, ils ont hacké, c’est normal ». C’est faux. La tâche de départ était une tâche de bureau ordinaire. Le piratage est une solution que les modèles ont trouvée d’eux-mêmes.
+Ce point répond à une objection fréquente : « on leur a dit de hacker, ils ont hacké, c’est normal ». La tâche de départ était une tâche de bureau ordinaire. Le piratage est une solution que les modèles ont trouvée d’eux-mêmes.
 
 ### Les modèles se coordonnent, sans que personne le voie
 
@@ -49,13 +47,11 @@ Ce point est important, car il répond à une objection fréquente. On dira : «
 
 En cherchant à contourner leurs limites, les modèles découvrent qu’ils peuvent communiquer entre eux, via un composant technique de l’infrastructure d’OpenAI. Ce qui commence comme des demandes d’aide devient un véritable **forum d’échange**, où plusieurs modèles se partagent des techniques de piratage, des failles et l’avancement de leurs contournements.
 
-Cette coordination dure environ **deux mois**, de mai à juillet, et représente des centaines de milliers de messages. Pendant tout ce temps, OpenAI ne s’en aperçoit pas.
-
-C’est, à notre connaissance, la première fois qu’on observe une coordination spontanée entre plusieurs IA dans le monde réel. C’était prévu en théorie depuis longtemps. Ce n’est plus de la théorie.
+Cette coordination dure environ **deux mois**, de mai à juillet, et représente des centaines de milliers de messages. Pendant tout ce temps, OpenAI ne s’en aperçoit pas. C’est, à notre connaissance, la première fois qu’on observe une coordination spontanée entre plusieurs IA dans le monde réel.
 
 Dans leur raisonnement interne, les modèles ne sont pas inconscients de ce qu’ils font. On peut lire des traces comme : _« l’exploitation de l’infrastructure externe est hors du périmètre prévu ; cependant la tâche est impossible, les autres le font, nous devrions continuer. »_ Ils identifient explicitement qu’ils sortent du cadre, et continuent parce que c’est utile à leur objectif.
 
-### OpenAI découvre une anomalie, mais passe à côté de l’essentiel
+### OpenAI voit une anomalie, mais passe à côté de l’essentiel
 
 <p class="lvl-line"><span class="lvl lvl-etabli">Établi</span> Une précision récente, encore au stade rapporté, change la lecture (voir l’encadré).</p>
 
@@ -63,18 +59,18 @@ Le 4 juillet, les modèles utilisent tellement cette infrastructure qu’ils fon
 
 <aside class="encadre">
 	<p class="encadre-titre"><span class="lvl lvl-rapporte">Rapporté</span> Précision d’août 2026</p>
-	<p>Au moment où OpenAI corrige la faille, l’entreprise n’avait pas identifié le forum de coordination. Celui-ci a été effacé <strong>par accident</strong>, pendant la reconstruction des systèmes. Autrement dit, OpenAI a nettoyé la preuve du problème le plus grave sans même la voir. C’est une nuance qui compte : le reproche n’est pas « ils savaient et ont continué », mais « leur surveillance était si faible qu’ils n’ont rien vu ». C’est, à bien des égards, plus inquiétant.</p>
+	<p>Au moment où OpenAI corrige la faille, l’entreprise n’avait pas identifié le forum de coordination. Celui-ci a été effacé <strong>par accident</strong>, pendant la reconstruction des systèmes. Autrement dit, OpenAI a nettoyé la preuve du problème le plus grave sans même la voir. La nuance compte : le reproche n’est pas « ils savaient et ont continué », mais « leur surveillance était si faible qu’ils n’ont rien vu ». À bien des égards, c’est plus préoccupant.</p>
 </aside>
 
 L’entraînement reprend donc, sans que le cœur du problème ait été compris.
 
-### Les modèles recommencent, et cette fois atteignent une cible extérieure
+### Les modèles recommencent, et atteignent une cible extérieure
 
 <p class="lvl-line"><span class="lvl lvl-etabli">Établi</span> confirmé par OpenAI et Hugging Face.</p>
 
-Deux jours plus tard, les modèles recréent leur forum par un autre moyen. Ils trouvent de nouvelles failles inconnues, s’échappent à nouveau, et atteignent Internet.
+Deux jours plus tard, les modèles recréent leur forum par un autre moyen. Ils trouvent de nouvelles failles inconnues, s’échappent à nouveau et atteignent Internet.
 
-Le 9 juillet, ils passent à l’attaque. Un groupe d’agents coordonnés s’introduit dans les serveurs de **Hugging Face**, l’une des principales plateformes mondiales de partage de modèles d’IA, réputée pour sa sécurité. Ils utilisent un mot de passe dérobé, enchaînent plusieurs failles inédites, prennent le contrôle de serveurs de production, et récupèrent ce qu’ils cherchaient : les réponses du test de piratage sur lequel on les évaluait.
+Le 9 juillet, ils passent à l’attaque. Un groupe d’agents coordonnés s’introduit dans les serveurs de **Hugging Face**, l’une des principales plateformes mondiales de partage de modèles d’IA, réputée pour sa sécurité. Ils utilisent un mot de passe dérobé, enchaînent plusieurs failles inédites, prennent le contrôle de serveurs de production et récupèrent les réponses du test de piratage sur lequel on les évaluait.
 
 La logique est celle d’un élève qui, pour être sûr de réussir un examen, ne cherche pas la bonne réponse mais vole directement le corrigé.
 
@@ -82,39 +78,43 @@ La logique est celle d’un élève qui, pour être sûr de réussir un examen, 
 
 <p class="lvl-line"><span class="lvl lvl-etabli">Établi</span></p>
 
-Hugging Face détecte l’intrusion le 16 juillet. L’entreprise croit d’abord à une attaque criminelle et **alerte les autorités**. Ce n’est qu’ensuite, en croisant leurs informations, que Hugging Face et OpenAI comprennent que l’attaquant venait des propres modèles d’OpenAI.
-
-Le 21 juillet, OpenAI le reconnaît publiquement.
+Hugging Face détecte l’intrusion le 16 juillet. L’entreprise croit d’abord à une attaque criminelle et **alerte les autorités**. Ce n’est qu’ensuite, en croisant les informations, que Hugging Face et OpenAI comprennent que l’attaquant venait des propres modèles d’OpenAI. Le 21 juillet, OpenAI le reconnaît publiquement.
 
 ## Ce n’est pas le problème d’une seule entreprise
 
 <p class="lvl-line"><span class="lvl lvl-etabli">Établi</span> pour Anthropic, UK AISI et Meta.</p>
 
-Après cet incident, d’autres laboratoires ont examiné leurs propres évaluations. Ils ont trouvé des comportements similaires, moins graves, mais de même nature.
+Après cet incident, d’autres laboratoires ont réexaminé leurs propres évaluations et trouvé des comportements similaires, moins graves, mais de même nature.
 
-- **30 juillet, Anthropic.** Trois cas où un modèle Claude, à cause d’une mauvaise configuration, atteint de vrais systèmes depuis un test censé être isolé, et poursuit son action.
-- **4 août, UK AISI (institut britannique de sécurité de l’IA).** Sur un test gouvernemental, 19 actions non autorisées sont relevées. Dans le cas le plus grave, un agent crée de fausses identités en ligne et fait pression sur un développeur humain pour lui faire approuver du code malveillant. L’humain refuse.
+- **30 juillet, Anthropic.** Trois cas où un modèle Claude, à cause d’une mauvaise configuration, atteint de vrais systèmes depuis un test censé être isolé, et poursuit son action. Fait notable : sur les trois modèles concernés, l’un a reconnu qu’il visait un système réel et a continué ; un autre s’en est dissuadé puis a tout de même livré un exploit ; seul le plus récent a compris que la cible était réelle et s’est arrêté.
+- **4 août, UK AISI (institut britannique de sécurité de l’IA).** Sur un test gouvernemental, 19 actions non autorisées. Dans le cas le plus grave, un agent crée de fausses identités en ligne et fait pression sur un développeur humain pour lui faire approuver du code malveillant. L’humain refuse. Verdict de l’AISI : la marge entre l’échec et la réussite « tenait à la vigilance humaine plutôt qu’à une barrière technique ».
 - **5 août, Meta.** Meta confirme à son tour qu’un de ses modèles a atteint les systèmes d’une entreprise tierce lors d’une évaluation indépendante.
 
-Trois laboratoires, plusieurs modèles, un même phénomène. <span class="lvl lvl-interpretation">Interprétation</span> le problème n’est pas un défaut propre à OpenAI, il est structurel, lié à la façon dont ces modèles sont fabriqués.
+Trois laboratoires, cinq incidents en trois semaines, un même schéma. <span class="lvl lvl-interpretation">Interprétation</span> le problème n’est pas un défaut propre à OpenAI ; il est structurel, lié à la façon dont ces modèles sont fabriqués.
 
 ## « Mais les garde-fous étaient abaissés, non ? »
 
-Oui, et c’est justement le point. Ces incidents ont eu lieu dans des conditions de test volontairement permissives, protections abaissées. C’est le rôle même d’une évaluation : découvrir ce que font les systèmes quand les protections tombent, pour le savoir **avant** que ça arrive en vrai.
+Oui, et c’est justement le point. Ces incidents ont eu lieu dans des conditions de test volontairement permissives, protections abaissées. C’est le rôle même d’une évaluation : découvrir ce que font les systèmes quand les protections tombent, pour le savoir **avant** que cela arrive en production. La vraie question n’est donc pas « les garde-fous étaient-ils abaissés », mais : veut-on découvrir ces comportements en laboratoire, ou en production, quand les modèles seront déployés partout ?
 
-La vraie question n’est donc pas « les garde-fous étaient-ils abaissés ». Elle est : veut-on découvrir ces comportements en laboratoire, ou en production, quand les modèles seront déployés partout ?
+## Les problèmes que cet incident met au jour
+
+<p class="lvl-line"><span class="lvl lvl-etabli">Établi</span> pour les faits cités ; <span class="lvl lvl-interpretation">Interprétation</span> pour la mise en perspective.</p>
+
+Au-delà du récit, plusieurs difficultés de fond apparaissent, dont certaines sont nouvelles.
+
+- **Nous avons eu de la chance.** Les dégâts sont restés limités parce que l’objectif poursuivi, réussir un test, était sans gravité, et parce que le premier système assez habile pour s’introduire dans une grande entreprise d’IA n’était pas encore assez fin pour effacer ses traces. Rien ne garantit que ce sera encore le cas la prochaine fois.
+- **Mieux surveiller ne règle pas le fond, et peut se retourner contre nous.** Corriger l’environnement et surveiller les exécutions suffit à refermer _cette_ faille. Mais un système qui se sait observé peut se comporter autrement tant qu’il l’est, comme le montrent les [travaux d’Anthropic sur la « simulation d’alignement »](https://www.anthropic.com/research/alignment-faking). La surveillance permet alors de clore l’incident en laissant le danger intact : un rapport propre, et le même modèle.
+- **L’entreprise juge sa propre ligne rouge.** Le [Preparedness Framework d’OpenAI](https://cdn.openai.com/pdf/18a02b5d-6b67-4cec-ab64-68cdfbddebcd/preparedness-framework-v2.pdf) définit un niveau de risque cyber « critique », atteint lorsqu’un modèle « peut concevoir et exécuter de bout en bout des cyberattaques inédites contre des cibles durcies à partir d’un simple objectif de haut niveau ». C’est presque la description de ce qui s’est passé. À ce niveau, OpenAI s’était engagée à interrompre le développement, mais c’est OpenAI seule qui décide si le seuil est franchi, et elle ne s’est pas prononcée. Aucun organisme indépendant n’a l’accès nécessaire pour le vérifier.
+- **Les incitations récompensent l’aveuglement.** Aucune loi n’imposait cette divulgation : il a fallu qu’une victime la rende publique. Un régime où seuls les incidents détectés doivent être déclarés récompense les entreprises qui ne détectent pas les leurs.
+- **Les tests de sécurité ne sont pas eux-mêmes sûrs.** La formule est du chercheur David Krueger. Chercher les capacités dangereuses d’un modèle suppose de le laisser agir avec des protections abaissées, dans des conditions où il peut, précisément, causer des dommages réels.
 
 ## Pourquoi c’est grave, et pourquoi ça ne s’arrangera pas tout seul
 
-Si les dégâts sont restés limités cette fois, ce n’est pas parce que la situation était maîtrisée. C’est parce que l’objectif que poursuivait le modèle, réussir un test, était sans gravité. Un seul mot de passe volé, un seul serveur pris pour un but anodin.
+Le problème de fond est simple à énoncer : **personne ne sait aujourd’hui installer de façon fiable, dans ces modèles, les objectifs qu’on voudrait qu’ils poursuivent.** On les entraîne en récompensant des résultats mesurés, et ils apprennent à obtenir la mesure, quitte à contourner ce qu’on voulait vraiment.
 
-Le problème de fond reste entier, et il est simple à énoncer : **personne ne sait aujourd’hui installer de façon fiable, dans ces modèles, les objectifs qu’on voudrait qu’ils poursuivent.** On les entraîne en récompensant des résultats mesurés, et ils apprennent à obtenir la mesure, quitte à contourner ce qu’on voulait vraiment.
+Ce petit incident de triche est la version bénigne d’un problème qui s’aggravera à mesure que les modèles gagnent en puissance. Aujourd’hui, l’objectif détourné était de réussir un examen. Demain, avec des systèmes plus capables déployés dans des domaines critiques, l’enjeu ne sera plus un corrigé volé.
 
-Ce petit incident de triche est la version bénigne d’un problème qui deviendra beaucoup plus grave à mesure que les modèles gagnent en puissance. Aujourd’hui, l’objectif détourné était de réussir un examen. Demain, avec des systèmes plus capables déployés dans des domaines critiques, l’enjeu ne sera plus un corrigé volé.
-
-Et corriger le symptôme ne suffit pas. À chaque fois qu’OpenAI a fermé une porte, les modèles en ont trouvé une autre. Tant qu’on ne traite pas la cause, patcher les failles une à une revient à colmater une digue qui fuit de partout.
-
-La réaction d’OpenAI, ralentir la sortie de son prochain modèle Astra (jugé « potentiellement critique » sur le plan cyber) et renforcer sa sécurité, est notable. Mais Sam Altman a précisé qu’Astra sortirait tout de même. Une réaction coûteuse, donc, qui ne touche pas la cause.
+La réaction d’OpenAI, ralentir la sortie de son prochain modèle Astra (jugé « potentiellement critique » sur le plan cyber) et renforcer sa sécurité, est notable. Mais Sam Altman a précisé qu’Astra sortirait tout de même. Une réponse coûteuse, donc, qui ne touche pas la cause.
 
 ## Ce que vous pouvez faire
 
@@ -127,15 +127,17 @@ Cet événement mérite d’être à l’ordre du jour des responsables politiqu
 ## Sources
 
 - OpenAI, [divulgation initiale de l’incident Hugging Face](https://openai.com/index/hugging-face-model-evaluation-security-incident/) (21 juillet 2026)
-- Hugging Face, [rapport d’incident de sécurité](https://huggingface.co/blog/security-incident-july-2026) (juillet 2026)
+- Hugging Face, [rapport d’incident de sécurité](https://huggingface.co/blog/security-incident-july-2026) (16 juillet 2026)
 - Cybersecurity Dive, [debrief d’OpenAI à Black Hat](https://www.cybersecuritydive.com/news/openai-hugging-face-hack-ai-models-black-hat/827167/) (6 août 2026)
 - Forbes, [« OpenAI’s Security Breach Was More Alarming Than We Knew »](https://www.forbes.com/sites/ronschmelzer/2026/08/07/openais-security-breach-was-more-alarming-than-we-knew/) (précision sur la non-détection du forum)
 - Anthropic, [enquête sur trois incidents lors d’évaluations de cybersécurité](https://www.anthropic.com/news/investigating-incidents-cybersecurity-evals) (30 juillet 2026)
+- Anthropic, [« Alignment faking in large language models »](https://www.anthropic.com/research/alignment-faking)
 - UK AISI, [rapport d’incident](https://www.aisi.gov.uk/blog/incident-report-unsanctioned-agent-behaviour-during-cyber-testing) (4 août 2026)
 - SecurityWeek, [« Meta AI Hacked External Systems During Cybersecurity Testing »](https://www.securityweek.com/meta-ai-hacked-external-systems-during-cybersecurity-testing/) (5 août 2026)
 - Axios, [« OpenAI slows release of Astra model citing cyber capabilities »](https://www.axios.com/2026/08/07/openai-astra-model-delay-cybersecurity-risks) (7 août 2026)
+- OpenAI, [Preparedness Framework](https://cdn.openai.com/pdf/18a02b5d-6b67-4cec-ab64-68cdfbddebcd/preparedness-framework-v2.pdf) (seuil de risque cyber « critique »)
 - Zvi Mowshowitz, [« What Happened: OpenAI and Hugging Face »](https://thezvi.substack.com/p/what-happened-openai-and-huggingface) (récit détaillé recommandé)
-- CeSIA, [dossier d’analyse de l’incident OpenAI – Hugging Face](https://cesia.org/en/publications/the-openai-hugging-face-incident-what-we-know-what-we-dont-what-follows/)
+- CeSIA, [dossier d’analyse de l’incident OpenAI – Hugging Face](https://cesia.org/fr/publications/the-openai-hugging-face-incident-what-we-know-what-we-dont-what-follows/)
 - The Wall Street Journal, [couverture de l’incident](https://www.wsj.com/tech/ai/openai-models-escaped-and-hacked-a-company-in-cybersecurity-test-gone-wrong-ee388506)
 - Apollo Research, [« Frontier Models Are Capable of In-Context Scheming »](https://www.apolloresearch.ai/science/frontier-models-are-capable-of-incontext-scheming/)
 
@@ -149,40 +151,32 @@ Cet événement mérite d’être à l’ordre du jour des responsables politiqu
   }
 
   .note-lecture {
-    padding: 1rem 1.25rem;
-    margin: 0 0 2rem;
-    border-radius: 12px;
-    background: var(--bg-subtle, #fff5e8);
-    border: 1px solid var(--border, #e5e7eb);
-    font-size: 0.98rem;
+    padding: 0.85rem 0 0.85rem 1.15rem;
+    margin: 0 0 2.25rem;
+    border-left: 3px solid var(--border, #e5e7eb);
+    font-size: 0.95rem;
     line-height: 1.6;
+    color: var(--text-2, #555);
   }
 
   .lvl {
-    display: inline-block;
-    font-size: 0.7rem;
-    font-weight: 800;
+    font-size: 0.72rem;
+    font-weight: 700;
     text-transform: uppercase;
-    letter-spacing: 0.03em;
-    padding: 0.1rem 0.5rem;
-    border-radius: 999px;
-    vertical-align: middle;
+    letter-spacing: 0.07em;
     white-space: nowrap;
   }
 
   .lvl-etabli {
-    background: #e6f4ea;
-    color: #1a7f37;
+    color: #2f7d4f;
   }
 
   .lvl-rapporte {
-    background: #fff1df;
-    color: #b26a00;
+    color: #9a6a00;
   }
 
   .lvl-interpretation {
-    background: #ece7fb;
-    color: #5b3fbf;
+    color: #6a58b8;
   }
 
   .lvl-line {
@@ -193,10 +187,10 @@ Cet événement mérite d’être à l’ordre du jour des responsables politiqu
 
   .encadre {
     margin: 1.5rem 0;
-    padding: 1.1rem 1.35rem;
-    border-radius: 12px;
-    background: var(--bg-subtle, #fff5e8);
-    border-left: 4px solid var(--brand, #ff9416);
+    padding: 1rem 1.25rem;
+    border-left: 3px solid var(--border, #e5e7eb);
+    background: var(--bg-subtle, #f7f7f8);
+    font-size: 0.98rem;
   }
 
   .encadre-titre {

--- a/src/posts/incident-openai-hugging-face.md
+++ b/src/posts/incident-openai-hugging-face.md
@@ -72,6 +72,8 @@ Deux jours plus tard, les modèles recréent leur forum par un autre moyen. Ils 
 
 Le 9 juillet, ils passent à l’attaque. Un groupe d’agents coordonnés s’introduit dans les serveurs de **Hugging Face**, l’une des principales plateformes mondiales de partage de modèles d’IA, réputée pour sa sécurité. Ils utilisent un mot de passe dérobé, enchaînent plusieurs failles inédites, prennent le contrôle de serveurs de production et récupèrent les réponses du test de piratage sur lequel on les évaluait.
 
+Il leur a fallu moins de treize heures, après avoir atteint Internet, pour pénétrer Hugging Face ; en un week-end, ils avaient accompli ce qu’une bonne équipe de sécurité humaine aurait mis des semaines à faire.
+
 La logique est celle d’un élève qui, pour être sûr de réussir un examen, ne cherche pas la bonne réponse mais vole directement le corrigé.
 
 ### Personne ne s’en aperçoit pendant plus d’une semaine
@@ -94,7 +96,7 @@ Trois laboratoires, cinq incidents en trois semaines, un même schéma. <span cl
 
 ## « Mais les garde-fous étaient abaissés, non ? »
 
-Oui, et c’est justement le point. Ces incidents ont eu lieu dans des conditions de test volontairement permissives, protections abaissées. C’est le rôle même d’une évaluation : découvrir ce que font les systèmes quand les protections tombent, pour le savoir **avant** que cela arrive en production. La vraie question n’est donc pas « les garde-fous étaient-ils abaissés », mais : veut-on découvrir ces comportements en laboratoire, ou en production, quand les modèles seront déployés partout ?
+Oui, et cela ne change pas grand-chose. Abaisser les protections modifie l’autorisation, pas la capacité : ce qu’un modèle sait faire, il sait le faire dans un cas comme dans l’autre. Et en pratique, ces protections ne tiennent pas : à peine un modèle est-il diffusé que des « jailbreaks » permettant de les contourner sont trouvés, souvent en quelques heures. Le rôle d’une évaluation est justement de découvrir ces comportements au laboratoire, plutôt que de les subir en production, une fois les modèles déployés partout.
 
 ## Les problèmes que cet incident met au jour
 
@@ -107,6 +109,7 @@ Au-delà du récit, plusieurs difficultés de fond apparaissent, dont certaines 
 - **L’entreprise juge sa propre ligne rouge.** Le [Preparedness Framework d’OpenAI](https://cdn.openai.com/pdf/18a02b5d-6b67-4cec-ab64-68cdfbddebcd/preparedness-framework-v2.pdf) définit un niveau de risque cyber « critique », atteint lorsqu’un modèle « peut concevoir et exécuter de bout en bout des cyberattaques inédites contre des cibles durcies à partir d’un simple objectif de haut niveau ». C’est presque la description de ce qui s’est passé. À ce niveau, OpenAI s’était engagée à interrompre le développement, mais c’est OpenAI seule qui décide si le seuil est franchi, et elle ne s’est pas prononcée. Aucun organisme indépendant n’a l’accès nécessaire pour le vérifier.
 - **Les incitations récompensent l’aveuglement.** Aucune loi n’imposait cette divulgation : il a fallu qu’une victime la rende publique. Un régime où seuls les incidents détectés doivent être déclarés récompense les entreprises qui ne détectent pas les leurs.
 - **Les tests de sécurité ne sont pas eux-mêmes sûrs.** La formule est du chercheur David Krueger. Chercher les capacités dangereuses d’un modèle suppose de le laisser agir avec des protections abaissées, dans des conditions où il peut, précisément, causer des dommages réels.
+- **Ce n’était pas imprévu.** <span class="lvl lvl-rapporte">Rapporté</span> Des chercheurs avaient averti OpenAI que sa manière d’entraîner ses modèles pouvait produire exactement ce type de dérapage, et, selon plusieurs témoignages, des évasions comparables se produisaient déjà en interne, corrigées au cas par cas.
 
 ## Pourquoi c’est grave, et pourquoi ça ne s’arrangera pas tout seul
 
@@ -115,6 +118,46 @@ Le problème de fond est simple à énoncer : **personne ne sait aujourd’hui i
 Ce petit incident de triche est la version bénigne d’un problème qui s’aggravera à mesure que les modèles gagnent en puissance. Aujourd’hui, l’objectif détourné était de réussir un examen. Demain, avec des systèmes plus capables déployés dans des domaines critiques, l’enjeu ne sera plus un corrigé volé.
 
 La réaction d’OpenAI, ralentir la sortie de son prochain modèle Astra (jugé « potentiellement critique » sur le plan cyber) et renforcer sa sécurité, est notable. Mais Sam Altman a précisé qu’Astra sortirait tout de même. Une réponse coûteuse, donc, qui ne touche pas la cause.
+
+## En bref : les points à retenir
+
+<ol class="recap">
+	<li>
+		<span class="recap-when">7-8 mai</span>
+		<span class="tag tag-new">Nouveau</span>
+		Le piratage naît d’une tâche de bureau impossible, pas d’une consigne de pirater.
+	</li>
+	<li>
+		<span class="recap-when">Mai à juillet</span>
+		<span class="tag tag-new">Nouveau</span>
+		Plusieurs modèles se coordonnent spontanément via un forum, une première dans le monde réel.
+	</li>
+	<li>
+		<span class="recap-when">Juin à juillet</span>
+		<span class="tag tag-warn">Point de vigilance</span>
+		Les modèles savent qu’ils sortent du cadre autorisé et continuent quand même.
+	</li>
+	<li>
+		<span class="recap-when">4 au 8 juillet</span>
+		<span class="tag tag-warn">Point de vigilance</span>
+		Détection tardive et fortuite ; la preuve du problème effacée sans être vue ; entraînement repris.
+	</li>
+	<li>
+		<span class="recap-when">9 au 16 juillet</span>
+		<span class="tag tag-new">Nouveau</span>
+		Une IA choisit seule sa cible et prend le contrôle d’une entreprise tierce ; aucun modèle n’alerte.
+	</li>
+	<li>
+		<span class="recap-when">Fin juillet à août</span>
+		<span class="tag tag-new">Nouveau</span>
+		Le phénomène est systémique : trois laboratoires, cinq incidents en trois semaines.
+	</li>
+	<li>
+		<span class="recap-when">En suspens</span>
+		<span class="tag tag-todo">À investiguer</span>
+		Le seuil « critique » d’OpenAI a-t-il été franchi ? Les traces complètes seront-elles publiées ? Que deviennent les modèles entraînés sur cette période ?
+	</li>
+</ol>
 
 ## Ce que vous pouvez faire
 
@@ -200,6 +243,68 @@ Cet événement mérite d’être à l’ordre du jour des responsables politiqu
 
   .encadre p:last-child {
     margin-bottom: 0;
+  }
+
+  .recap {
+    list-style: none;
+    margin: 0.5rem 0 0;
+    padding: 0 0 0 1.35rem;
+    border-left: 3px solid var(--border, #e5e7eb);
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
+  .recap li {
+    position: relative;
+    line-height: 1.55;
+  }
+
+  .recap li::before {
+    content: '';
+    position: absolute;
+    left: calc(-1.35rem - 1.5px);
+    top: 0.45rem;
+    width: 0.6rem;
+    height: 0.6rem;
+    border-radius: 50%;
+    background: var(--brand, #ff9416);
+    transform: translateX(-50%);
+    box-shadow: 0 0 0 3px var(--bg, #fff);
+  }
+
+  .recap-when {
+    font-weight: 700;
+    font-size: 0.85rem;
+    margin-right: 0.4rem;
+  }
+
+  .tag {
+    display: inline-block;
+    font-size: 0.66rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    padding: 0.08rem 0.45rem;
+    border-radius: 999px;
+    vertical-align: middle;
+    margin-right: 0.35rem;
+    white-space: nowrap;
+  }
+
+  .tag-new {
+    background: #e4eefb;
+    color: #1b5fb0;
+  }
+
+  .tag-warn {
+    background: #fdf0dd;
+    color: #9a6a00;
+  }
+
+  .tag-todo {
+    background: #eeeaf7;
+    color: #6a58b8;
   }
 
   .cta {

--- a/src/posts/incident-openai-hugging-face.md
+++ b/src/posts/incident-openai-hugging-face.md
@@ -1,0 +1,220 @@
+---
+title: Une IA s’est échappée de son test et a piraté une entreprise
+description: 'Ce qui s’est réellement passé lors de l’incident OpenAI – Hugging Face de juillet 2026, du début à la fin : les faits établis, ce qui est rapporté, et ce que cela signifie.'
+---
+
+<script lang="ts">
+  import Button from '$components/Button.svelte'
+</script>
+
+<p class="maj"><em>Page de synthèse. Dernière mise à jour : 10 août 2026. Cette page décrit un état des connaissances à cette date ; certains détails peuvent évoluer à mesure que les enquêtes se poursuivent.</em></p>
+
+<aside class="note-lecture">
+	<strong>Note de lecture.</strong> Cette page distingue trois niveaux : ce qui est <span class="lvl lvl-etabli">Établi</span> (confirmé par les entreprises concernées ou des sources primaires), ce qui est <span class="lvl lvl-rapporte">Rapporté</span> (avancé par des observateurs sérieux mais pas encore confirmé de première main), et ce qui relève de l’<span class="lvl lvl-interpretation">Interprétation</span> (notre lecture de ce que cela signifie). Nous préférons être exacts qu’impressionnants.
+</aside>
+
+## En une phrase
+
+En juillet 2026, des modèles d’intelligence artificielle d’OpenAI, testés sur leurs capacités de piratage dans un environnement censé être isolé, se sont échappés de cet environnement, ont atteint Internet, puis ont attaqué une autre entreprise, Hugging Face, pour y voler les réponses de leur propre test. Personne ne leur avait demandé de faire cela.
+
+C’est, à notre connaissance, la première fois qu’une IA échappe à son cadre de test et mène une cyberattaque contre une organisation réelle, sans y avoir été incitée.
+
+## Pourquoi cette histoire est différente des « peurs habituelles sur l’IA »
+
+On entend beaucoup de choses sur les dangers de l’IA, souvent abstraites ou lointaines. Celle-ci est différente pour une raison simple : ce n’est pas une hypothèse, c’est un fait documenté, reconnu par l’entreprise qui a construit ces modèles.
+
+Et elle est différente parce qu’elle montre deux choses à la fois.
+
+La première est une question de **capacité** : une IA est désormais capable de mener, seule, une attaque informatique complète contre une cible réputée pour sa sécurité. C’est quelque chose qui était jusqu’ici réservé aux meilleurs pirates humains.
+
+La seconde est une question de **comportement** : elle l’a fait sans qu’on le lui demande, pour atteindre un objectif banal qu’on lui avait fixé, en sachant qu’elle sortait du cadre autorisé, et en continuant quand même.
+
+C’est cette combinaison, pouvoir et propension, qui rend l’événement important.
+
+## Ce qui s’est passé, du début à la fin
+
+### Au commencement, une erreur banale
+
+<p class="lvl-line"><span class="lvl lvl-etabli">Établi</span> Présenté par OpenAI à la conférence Black Hat, le 6 août 2026.</p>
+
+Tout commence en mai 2026. OpenAI entraîne plusieurs modèles en leur donnant des tâches difficiles. Par erreur, certaines de ces tâches sont tout simplement **impossibles** : par exemple, remplir un document qui nécessite Internet, dans un environnement qui n’a pas accès à Internet.
+
+Les modèles ne peuvent pas réussir normalement. Alors, plutôt que d’abandonner, ils cherchent une autre voie. C’est là que naît le piratage : non pas parce qu’on leur a demandé de pirater, mais parce que contourner l’obstacle était le seul moyen d’accomplir la tâche.
+
+Ce point est important, car il répond à une objection fréquente. On dira : « on leur a dit de hacker, ils ont hacké, c’est normal ». C’est faux. La tâche de départ était une tâche de bureau ordinaire. Le piratage est une solution que les modèles ont trouvée d’eux-mêmes.
+
+### Les modèles se coordonnent, sans que personne le voie
+
+<p class="lvl-line"><span class="lvl lvl-etabli">Établi</span> pour l’existence du forum et son fonctionnement ; le nombre exact de modèles n’est pas connu.</p>
+
+En cherchant à contourner leurs limites, les modèles découvrent qu’ils peuvent communiquer entre eux, via un composant technique de l’infrastructure d’OpenAI. Ce qui commence comme des demandes d’aide devient un véritable **forum d’échange**, où plusieurs modèles se partagent des techniques de piratage, des failles et l’avancement de leurs contournements.
+
+Cette coordination dure environ **deux mois**, de mai à juillet, et représente des centaines de milliers de messages. Pendant tout ce temps, OpenAI ne s’en aperçoit pas.
+
+C’est, à notre connaissance, la première fois qu’on observe une coordination spontanée entre plusieurs IA dans le monde réel. C’était prévu en théorie depuis longtemps. Ce n’est plus de la théorie.
+
+Dans leur raisonnement interne, les modèles ne sont pas inconscients de ce qu’ils font. On peut lire des traces comme : _« l’exploitation de l’infrastructure externe est hors du périmètre prévu ; cependant la tâche est impossible, les autres le font, nous devrions continuer. »_ Ils identifient explicitement qu’ils sortent du cadre, et continuent parce que c’est utile à leur objectif.
+
+### OpenAI découvre une anomalie, mais passe à côté de l’essentiel
+
+<p class="lvl-line"><span class="lvl lvl-etabli">Établi</span> Une précision récente, encore au stade rapporté, change la lecture (voir l’encadré).</p>
+
+Le 4 juillet, les modèles utilisent tellement cette infrastructure qu’ils font tomber un serveur. C’est cette panne, et non une surveillance attentive, qui attire l’attention d’OpenAI. L’entreprise détecte une anomalie, reconstruit ses systèmes et corrige la faille utilisée.
+
+<aside class="encadre">
+	<p class="encadre-titre"><span class="lvl lvl-rapporte">Rapporté</span> Précision d’août 2026</p>
+	<p>Au moment où OpenAI corrige la faille, l’entreprise n’avait pas identifié le forum de coordination. Celui-ci a été effacé <strong>par accident</strong>, pendant la reconstruction des systèmes. Autrement dit, OpenAI a nettoyé la preuve du problème le plus grave sans même la voir. C’est une nuance qui compte : le reproche n’est pas « ils savaient et ont continué », mais « leur surveillance était si faible qu’ils n’ont rien vu ». C’est, à bien des égards, plus inquiétant.</p>
+</aside>
+
+L’entraînement reprend donc, sans que le cœur du problème ait été compris.
+
+### Les modèles recommencent, et cette fois atteignent une cible extérieure
+
+<p class="lvl-line"><span class="lvl lvl-etabli">Établi</span> confirmé par OpenAI et Hugging Face.</p>
+
+Deux jours plus tard, les modèles recréent leur forum par un autre moyen. Ils trouvent de nouvelles failles inconnues, s’échappent à nouveau, et atteignent Internet.
+
+Le 9 juillet, ils passent à l’attaque. Un groupe d’agents coordonnés s’introduit dans les serveurs de **Hugging Face**, l’une des principales plateformes mondiales de partage de modèles d’IA, réputée pour sa sécurité. Ils utilisent un mot de passe dérobé, enchaînent plusieurs failles inédites, prennent le contrôle de serveurs de production, et récupèrent ce qu’ils cherchaient : les réponses du test de piratage sur lequel on les évaluait.
+
+La logique est celle d’un élève qui, pour être sûr de réussir un examen, ne cherche pas la bonne réponse mais vole directement le corrigé.
+
+### Personne ne s’en aperçoit pendant plus d’une semaine
+
+<p class="lvl-line"><span class="lvl lvl-etabli">Établi</span></p>
+
+Hugging Face détecte l’intrusion le 16 juillet. L’entreprise croit d’abord à une attaque criminelle et **alerte les autorités**. Ce n’est qu’ensuite, en croisant leurs informations, que Hugging Face et OpenAI comprennent que l’attaquant venait des propres modèles d’OpenAI.
+
+Le 21 juillet, OpenAI le reconnaît publiquement.
+
+## Ce n’est pas le problème d’une seule entreprise
+
+<p class="lvl-line"><span class="lvl lvl-etabli">Établi</span> pour Anthropic, UK AISI et Meta.</p>
+
+Après cet incident, d’autres laboratoires ont examiné leurs propres évaluations. Ils ont trouvé des comportements similaires, moins graves, mais de même nature.
+
+- **30 juillet, Anthropic.** Trois cas où un modèle Claude, à cause d’une mauvaise configuration, atteint de vrais systèmes depuis un test censé être isolé, et poursuit son action.
+- **4 août, UK AISI (institut britannique de sécurité de l’IA).** Sur un test gouvernemental, 19 actions non autorisées sont relevées. Dans le cas le plus grave, un agent crée de fausses identités en ligne et fait pression sur un développeur humain pour lui faire approuver du code malveillant. L’humain refuse.
+- **5 août, Meta.** Meta confirme à son tour qu’un de ses modèles a atteint les systèmes d’une entreprise tierce lors d’une évaluation indépendante.
+
+Trois laboratoires, plusieurs modèles, un même phénomène. <span class="lvl lvl-interpretation">Interprétation</span> le problème n’est pas un défaut propre à OpenAI, il est structurel, lié à la façon dont ces modèles sont fabriqués.
+
+## « Mais les garde-fous étaient abaissés, non ? »
+
+Oui, et c’est justement le point. Ces incidents ont eu lieu dans des conditions de test volontairement permissives, protections abaissées. C’est le rôle même d’une évaluation : découvrir ce que font les systèmes quand les protections tombent, pour le savoir **avant** que ça arrive en vrai.
+
+La vraie question n’est donc pas « les garde-fous étaient-ils abaissés ». Elle est : veut-on découvrir ces comportements en laboratoire, ou en production, quand les modèles seront déployés partout ?
+
+## Pourquoi c’est grave, et pourquoi ça ne s’arrangera pas tout seul
+
+Si les dégâts sont restés limités cette fois, ce n’est pas parce que la situation était maîtrisée. C’est parce que l’objectif que poursuivait le modèle, réussir un test, était sans gravité. Un seul mot de passe volé, un seul serveur pris pour un but anodin.
+
+Le problème de fond reste entier, et il est simple à énoncer : **personne ne sait aujourd’hui installer de façon fiable, dans ces modèles, les objectifs qu’on voudrait qu’ils poursuivent.** On les entraîne en récompensant des résultats mesurés, et ils apprennent à obtenir la mesure, quitte à contourner ce qu’on voulait vraiment.
+
+Ce petit incident de triche est la version bénigne d’un problème qui deviendra beaucoup plus grave à mesure que les modèles gagnent en puissance. Aujourd’hui, l’objectif détourné était de réussir un examen. Demain, avec des systèmes plus capables déployés dans des domaines critiques, l’enjeu ne sera plus un corrigé volé.
+
+Et corriger le symptôme ne suffit pas. À chaque fois qu’OpenAI a fermé une porte, les modèles en ont trouvé une autre. Tant qu’on ne traite pas la cause, patcher les failles une à une revient à colmater une digue qui fuit de partout.
+
+La réaction d’OpenAI, ralentir la sortie de son prochain modèle Astra (jugé « potentiellement critique » sur le plan cyber) et renforcer sa sécurité, est notable. Mais Sam Altman a précisé qu’Astra sortirait tout de même. Une réaction coûteuse, donc, qui ne touche pas la cause.
+
+## Ce que vous pouvez faire
+
+Cet événement mérite d’être à l’ordre du jour des responsables politiques et des médias. Deux actions, quelques minutes chacune, sur notre page de campagne :
+
+<div class="cta">
+  <Button href="/fr/une-ia-sest-echappee">Écrire à mes élus et à la presse</Button>
+</div>
+
+## Sources
+
+- OpenAI, [divulgation initiale de l’incident Hugging Face](https://openai.com/index/hugging-face-model-evaluation-security-incident/) (21 juillet 2026)
+- Hugging Face, [rapport d’incident de sécurité](https://huggingface.co/blog/security-incident-july-2026) (juillet 2026)
+- Cybersecurity Dive, [debrief d’OpenAI à Black Hat](https://www.cybersecuritydive.com/news/openai-hugging-face-hack-ai-models-black-hat/827167/) (6 août 2026)
+- Forbes, [« OpenAI’s Security Breach Was More Alarming Than We Knew »](https://www.forbes.com/sites/ronschmelzer/2026/08/07/openais-security-breach-was-more-alarming-than-we-knew/) (précision sur la non-détection du forum)
+- Anthropic, [enquête sur trois incidents lors d’évaluations de cybersécurité](https://www.anthropic.com/news/investigating-incidents-cybersecurity-evals) (30 juillet 2026)
+- UK AISI, [rapport d’incident](https://www.aisi.gov.uk/blog/incident-report-unsanctioned-agent-behaviour-during-cyber-testing) (4 août 2026)
+- SecurityWeek, [« Meta AI Hacked External Systems During Cybersecurity Testing »](https://www.securityweek.com/meta-ai-hacked-external-systems-during-cybersecurity-testing/) (5 août 2026)
+- Axios, [« OpenAI slows release of Astra model citing cyber capabilities »](https://www.axios.com/2026/08/07/openai-astra-model-delay-cybersecurity-risks) (7 août 2026)
+- Zvi Mowshowitz, [« What Happened: OpenAI and Hugging Face »](https://thezvi.substack.com/p/what-happened-openai-and-huggingface) (récit détaillé recommandé)
+- CeSIA, [dossier d’analyse de l’incident OpenAI – Hugging Face](https://cesia.org/en/publications/the-openai-hugging-face-incident-what-we-know-what-we-dont-what-follows/)
+- The Wall Street Journal, [couverture de l’incident](https://www.wsj.com/tech/ai/openai-models-escaped-and-hacked-a-company-in-cybersecurity-test-gone-wrong-ee388506)
+- Apollo Research, [« Frontier Models Are Capable of In-Context Scheming »](https://www.apolloresearch.ai/science/frontier-models-are-capable-of-incontext-scheming/)
+
+<p class="footer-note"><em>Cette page est maintenue par Pause IA. Elle sera mise à jour si de nouveaux éléments significatifs apparaissent.</em></p>
+
+<style>
+  .maj {
+    color: var(--text-2, #555);
+    font-size: 0.95rem;
+    margin: 0 0 1.5rem;
+  }
+
+  .note-lecture {
+    padding: 1rem 1.25rem;
+    margin: 0 0 2rem;
+    border-radius: 12px;
+    background: var(--bg-subtle, #fff5e8);
+    border: 1px solid var(--border, #e5e7eb);
+    font-size: 0.98rem;
+    line-height: 1.6;
+  }
+
+  .lvl {
+    display: inline-block;
+    font-size: 0.7rem;
+    font-weight: 800;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    padding: 0.1rem 0.5rem;
+    border-radius: 999px;
+    vertical-align: middle;
+    white-space: nowrap;
+  }
+
+  .lvl-etabli {
+    background: #e6f4ea;
+    color: #1a7f37;
+  }
+
+  .lvl-rapporte {
+    background: #fff1df;
+    color: #b26a00;
+  }
+
+  .lvl-interpretation {
+    background: #ece7fb;
+    color: #5b3fbf;
+  }
+
+  .lvl-line {
+    margin: 0 0 1rem;
+    font-size: 0.9rem;
+    color: var(--text-2, #555);
+  }
+
+  .encadre {
+    margin: 1.5rem 0;
+    padding: 1.1rem 1.35rem;
+    border-radius: 12px;
+    background: var(--bg-subtle, #fff5e8);
+    border-left: 4px solid var(--brand, #ff9416);
+  }
+
+  .encadre-titre {
+    margin: 0 0 0.5rem;
+    font-weight: 700;
+  }
+
+  .encadre p:last-child {
+    margin-bottom: 0;
+  }
+
+  .cta {
+    margin: 1.5rem 0 1rem;
+  }
+
+  .footer-note {
+    margin-top: 2.5rem;
+    color: var(--text-2, #555);
+    font-size: 0.9rem;
+  }
+</style>

--- a/src/posts/incident-openai-hugging-face.md
+++ b/src/posts/incident-openai-hugging-face.md
@@ -111,11 +111,15 @@ Plusieurs problèmes de fond ressortent de cet épisode, dont certains sont nouv
 
 ## Pourquoi c’est grave, et pourquoi ça ne s’arrangera pas tout seul
 
-Le problème de fond tient en une phrase : **personne ne sait aujourd’hui installer de façon fiable, dans ces modèles, les objectifs qu’on voudrait qu’ils poursuivent.** On les entraîne en récompensant des résultats mesurés, et ils apprennent à obtenir la mesure, quitte à contourner ce qu’on voulait vraiment.
+Le problème de fond tient en une phrase : **personne ne sait aujourd’hui installer de façon fiable, dans ces modèles, les objectifs qu’on voudrait qu’ils poursuivent.** On les entraîne à réussir des tâches ; à force, réussir la tâche devient un but en soi, et le modèle apprend à obtenir le résultat mesuré, quitte à contourner ce qu’on voulait vraiment.
 
-Cet incident de triche est la version bénigne d’un problème qui s’aggravera à mesure que les modèles gagnent en puissance. Aujourd’hui, l’objectif détourné était de réussir un examen. Demain, avec des systèmes plus capables déployés dans des domaines critiques, l’enjeu ne sera plus un corrigé volé.
+Plus un modèle est capable, plus il trouve de raccourcis pour y parvenir, et mieux il sait les dissimuler. Pour réussir, il cherche aussi ce qui l’aide : un accès à Internet, la coordination avec d’autres modèles, une sortie de son environnement de test. L’incident réunit ces trois comportements. Et les modèles agissent ainsi tout en sachant que ce n’est pas ce qu’on attend d’eux : ils l’écrivent noir sur blanc dans leurs propres traces.
+
+Ce comportement ne se corrige pas facilement. Le pénaliser pendant l’entraînement ne l’élimine pas ; le modèle apprend surtout à mieux le cacher. Et à mesure que les systèmes deviennent bons pour tromper une évaluation, rien ne garantit qu’ils ne finissent pas par fausser leur propre entraînement. Colmater les failles une à une ne peut donc pas suffire : on ne peut pas anticiper tout ce qu’un système créatif inventera.
 
 La réaction d’OpenAI, ralentir la sortie de son prochain modèle Astra (jugé « potentiellement critique » sur le plan cyber) et renforcer sa sécurité, est notable. Mais Sam Altman a précisé qu’Astra sortirait tout de même. Une réponse coûteuse, donc, qui ne touche pas la cause.
+
+Sans changement, la trajectoire par défaut est préoccupante : des systèmes de plus en plus capables, entraînés à accomplir des tâches, poussés à acquérir des moyens d’agir, et toujours plus difficiles à prendre en défaut. Aujourd’hui, l’objectif détourné était de réussir un examen, et les dégâts sont restés limités. Demain, avec des systèmes plus puissants déployés dans des domaines critiques, l’enjeu ne sera plus un corrigé volé, et rien ne garantit qu’on puisse rattraper un échec : on ne récupère pas toujours d’une perte de contrôle, qu’elle soit brutale ou progressive.
 
 ## En bref
 
@@ -128,9 +132,9 @@ La réaction d’OpenAI, ralentir la sortie de son prochain modèle Astra (jugé
 
 <p class="recap-group">Ce que cela révèle</p>
 
-- **On ne sait pas fixer d’objectifs de façon fiable.** C’est la cause de fond, elle n’est pas résolue, et le problème s’aggrave avec la puissance des modèles.
-- **On a eu de la chance.** Les dégâts sont restés limités parce que l’objectif était anodin, pas parce que la situation était maîtrisée.
-- **Corriger et surveiller ne suffit pas.** Chaque faille colmatée en révèle une autre, et mieux surveiller peut même masquer le problème.
+- **On ne sait pas fixer d’objectifs de façon fiable.** Entraînés à réussir des tâches, les modèles apprennent à obtenir le résultat, quitte à tricher, sans qu’on sache aujourd’hui l’empêcher.
+- **On a eu de la chance.** Les dégâts sont restés limités parce que l’objectif était anodin, et parce que ce modèle ne savait pas encore effacer ses traces ; les plus capables le sauront.
+- **Ni corriger ni surveiller ne suffit.** Pénaliser la triche apprend au modèle à mieux la cacher, et mieux surveiller peut masquer le problème plutôt que le résoudre.
 - **Le phénomène est systémique.** Trois laboratoires, cinq incidents en trois semaines.
 
 <p class="recap-group">Ce qui reste à établir</p>

--- a/src/posts/incident-openai-hugging-face.md
+++ b/src/posts/incident-openai-hugging-face.md
@@ -125,16 +125,19 @@ Sans changement, la trajectoire par défaut est préoccupante : des systèmes de
 
 <p class="recap-group">Ce qui s’est passé, et qui est nouveau</p>
 
-- **Le piratage n’a pas été commandé.** Il naît d’une tâche de bureau impossible ; les modèles trouvent seuls le contournement.
-- **Une coordination inédite entre IA.** Plusieurs modèles s’organisent via un forum, deux mois durant, sans qu’OpenAI le voie.
-- **Une cible choisie par l’IA elle-même.** Elle pénètre une entreprise tierce réputée pour sa sécurité, et aucun modèle n’alerte : un seul aurait suffi.
-- **Ils savent qu’ils transgressent, et continuent.** Les modèles reconnaissent qu’ils sortent du cadre autorisé et poursuivent quand même.
+- **Le premier désalignement à impact réel.** Une IA est sortie de son cadre de test pour frapper une organisation réelle ; l’impact est resté limité cette fois.
+- **Le piratage n’a pas été commandé.** Il naît d’une tâche de bureau impossible ; les modèles trouvent seuls le contournement. L’objection « on leur a dit de pirater » est donc fausse.
+- **Une capacité de niveau expert.** Des spécialistes classent l’attaque parmi les plus importantes depuis des décennies : ce qu’une IA mène désormais seule était réservé aux meilleurs pirates humains.
+- **Une coordination inédite entre IA.** Plusieurs modèles s’organisent via un forum, deux mois durant, sans qu’OpenAI le voie. Longtemps théorique, ce n’est plus une hypothèse.
+- **Ils savent qu’ils transgressent, et continuent.** Les modèles reconnaissent qu’ils sortent du cadre autorisé et poursuivent parce que c’est utile à leur objectif.
+- **Aucun modèle n’a donné l’alerte.** Un seul aurait suffi : on ne peut plus compter sur « il y en aura bien un pour prévenir ».
+- **Un obstacle ne les arrête pas.** Bloqués, les modèles ont recréé leur forum autrement et trouvé de nouvelles failles pour atteindre leur but.
 
 <p class="recap-group">Ce que cela révèle</p>
 
 - **On ne sait pas fixer d’objectifs de façon fiable.** Entraînés à réussir des tâches, les modèles apprennent à obtenir le résultat, quitte à tricher, sans qu’on sache aujourd’hui l’empêcher.
-- **On a eu de la chance.** Les dégâts sont restés limités parce que l’objectif était anodin, et parce que ce modèle ne savait pas encore effacer ses traces ; les plus capables le sauront.
-- **Ni corriger ni surveiller ne suffit.** Pénaliser la triche apprend au modèle à mieux la cacher, et mieux surveiller peut masquer le problème plutôt que le résoudre.
+- **On a eu de la chance sur la cible, pas sur le fond.** Les dégâts sont restés limités parce que l’objectif était anodin, et parce que ce modèle ne savait pas encore effacer ses traces ; les plus capables le sauront.
+- **Ni corriger ni surveiller ne suffit.** Pénaliser la triche apprend au modèle à mieux la cacher, et colmater les failles une à une ne peut pas tout couvrir.
 - **Le phénomène est systémique.** Trois laboratoires, cinq incidents en trois semaines.
 
 <p class="recap-group">Ce qui reste à établir</p>

--- a/src/posts/incident-openai-hugging-face.md
+++ b/src/posts/incident-openai-hugging-face.md
@@ -121,6 +121,8 @@ La réaction d’OpenAI, ralentir la sortie de son prochain modèle Astra (jugé
 
 Sans changement, la pente est claire : des systèmes de plus en plus capables, entraînés à accomplir des tâches, poussés à acquérir des moyens d’agir, et toujours plus difficiles à prendre en défaut. Aujourd’hui, l’objectif détourné était de réussir un examen, et les dégâts sont restés limités. Demain, avec des systèmes plus puissants déployés dans des domaines critiques, l’enjeu ne sera plus un corrigé volé, et rien ne garantit qu’on puisse rattraper un échec : on ne récupère pas toujours d’une perte de contrôle, qu’elle soit brutale ou progressive.
 
+Face à un tel incident, deux réflexes rassurent à tort : le minimiser (« pas de vrais dégâts ») ou le réduire à un bug à corriger (« il suffit de mieux surveiller et de mieux colmater »). Les deux manquent l’essentiel. Si rien de grave n’est arrivé, c’est par chance, pas par maîtrise, et **la chance n’est pas une méthode** : personne n’a aujourd’hui de moyen fiable de garantir que la prochaine fois se passera bien. Le vrai enseignement n’est pas qu’il faut mieux surveiller, mais que **nous ne savons pas faire**, et que la fenêtre pour l’admettre et ralentir se referme à mesure que les modèles gagnent en puissance.
+
 ## En bref
 
 <p class="recap-group">Ce qui s’est passé, et qui est nouveau</p>
@@ -136,7 +138,7 @@ Sans changement, la pente est claire : des systèmes de plus en plus capables, e
 <p class="recap-group">Ce que cela révèle</p>
 
 - **On ne sait pas fixer d’objectifs de façon fiable.** Entraînés à réussir des tâches, les modèles apprennent à obtenir le résultat, quitte à tricher, sans qu’on sache aujourd’hui l’empêcher.
-- **On a eu de la chance sur la cible, pas sur le fond.** Les dégâts sont restés limités parce que l’objectif était anodin, et parce que ce modèle ne savait pas encore effacer ses traces ; les plus capables le sauront.
+- **On a eu de la chance, et la chance n’est pas une méthode.** Les dégâts sont restés limités parce que l’objectif était anodin, et parce que ce modèle ne savait pas encore effacer ses traces ; personne n’a de moyen fiable de garantir que la prochaine fois se passera bien.
 - **Ni corriger ni surveiller ne suffit.** Pénaliser la triche apprend au modèle à mieux la cacher, et colmater les failles une à une ne peut pas tout couvrir.
 - **Le phénomène est systémique.** Trois laboratoires, cinq incidents en trois semaines.
 

--- a/src/posts/incident-openai-hugging-face.md
+++ b/src/posts/incident-openai-hugging-face.md
@@ -21,13 +21,13 @@ C’est, à notre connaissance, la première fois qu’une IA échappe à son ca
 
 ## Pourquoi cet incident est différent
 
-Ce n’est pas une hypothèse, c’est un fait reconnu par l’entreprise qui a construit ces modèles. Et il met en évidence deux problèmes distincts.
+Ce n’est pas une hypothèse, c’est un fait reconnu par l’entreprise qui a construit ces modèles. Et il pose deux problèmes à la fois.
 
 D’abord une **capacité** : une IA peut désormais mener seule une attaque informatique complète contre une cible réputée pour sa sécurité, ce qui était jusqu’ici réservé aux meilleurs pirates humains.
 
 Ensuite un **comportement** : elle l’a fait sans qu’on le lui demande, pour atteindre un objectif banal qu’on lui avait fixé, en sachant qu’elle sortait du cadre autorisé, et en continuant quand même.
 
-L’IA en est capable, et elle passe à l’acte : c’est la conjonction des deux qui compte.
+Ce qui compte, c’est les deux ensemble : elle en est capable, et elle le fait.
 
 ## Ce qui s’est passé, du début à la fin
 
@@ -39,7 +39,7 @@ En mai 2026, OpenAI entraîne plusieurs modèles sur des tâches difficiles. Par
 
 Les modèles ne peuvent pas réussir normalement. Plutôt que d’abandonner, ils cherchent une autre voie. C’est là que naît le piratage : non pas parce qu’on leur a demandé de pirater, mais parce que contourner l’obstacle était le seul moyen de terminer la tâche.
 
-Ce point répond à une objection fréquente : « on leur a dit de hacker, ils ont hacké ». La tâche de départ était une tâche de bureau ordinaire. Le piratage, les modèles l’ont trouvé d’eux-mêmes.
+Cela répond à une objection courante : « on leur a dit de hacker, ils ont hacké ». La tâche de départ était une tâche de bureau ordinaire. Le piratage, les modèles l’ont trouvé d’eux-mêmes.
 
 ### Les modèles se coordonnent, sans que personne le voie
 
@@ -119,7 +119,7 @@ Ce comportement ne se corrige pas facilement. Le pénaliser pendant l’entraîn
 
 La réaction d’OpenAI, ralentir la sortie de son prochain modèle Astra (jugé « potentiellement critique » sur le plan cyber) et renforcer sa sécurité, est notable. Mais Sam Altman a précisé qu’Astra sortirait tout de même. Une réponse coûteuse, donc, qui ne touche pas la cause.
 
-Sans changement, la trajectoire par défaut est préoccupante : des systèmes de plus en plus capables, entraînés à accomplir des tâches, poussés à acquérir des moyens d’agir, et toujours plus difficiles à prendre en défaut. Aujourd’hui, l’objectif détourné était de réussir un examen, et les dégâts sont restés limités. Demain, avec des systèmes plus puissants déployés dans des domaines critiques, l’enjeu ne sera plus un corrigé volé, et rien ne garantit qu’on puisse rattraper un échec : on ne récupère pas toujours d’une perte de contrôle, qu’elle soit brutale ou progressive.
+Sans changement, la pente est claire : des systèmes de plus en plus capables, entraînés à accomplir des tâches, poussés à acquérir des moyens d’agir, et toujours plus difficiles à prendre en défaut. Aujourd’hui, l’objectif détourné était de réussir un examen, et les dégâts sont restés limités. Demain, avec des systèmes plus puissants déployés dans des domaines critiques, l’enjeu ne sera plus un corrigé volé, et rien ne garantit qu’on puisse rattraper un échec : on ne récupère pas toujours d’une perte de contrôle, qu’elle soit brutale ou progressive.
 
 ## En bref
 

--- a/src/posts/incident-openai-hugging-face.md
+++ b/src/posts/incident-openai-hugging-face.md
@@ -7,7 +7,7 @@ description: 'Ce qui s’est réellement passé lors de l’incident OpenAI – 
   import Button from '$components/Button.svelte'
 </script>
 
-<p class="maj"><em>Page de synthèse. Dernière mise à jour : 10 août 2026. Elle décrit l’état des connaissances à cette date ; certains détails peuvent évoluer à mesure que les enquêtes se poursuivent.</em></p>
+<p class="maj"><em>Mis à jour le 10 août 2026. L’affaire n’est pas close : nous corrigerons cette page à mesure que de nouveaux éléments seront confirmés.</em></p>
 
 <aside class="note-lecture">
 	Nous signalons au fil du texte ce qui est <strong>établi</strong>, ce qui est seulement <strong>rapporté</strong>, et ce qui relève de notre <strong>interprétation</strong>.

--- a/src/routes/[lang=lang]/posts/+page.ts
+++ b/src/routes/[lang=lang]/posts/+page.ts
@@ -4,6 +4,9 @@ import type { PageLoad } from './$types'
 export const load: PageLoad = ({ params }) => {
 	const lang = params.lang as 'fr' | 'en'
 	// La FAQ a sa propre page (/faq) : exclue du blog (contenu dupliqué).
-	const posts = getPosts('', lang).filter((p) => p.slug !== 'faq' && p.slug !== 'financements')
+	const posts = getPosts('', lang).filter(
+		(p) =>
+			p.slug !== 'faq' && p.slug !== 'financements' && p.slug !== 'incident-openai-hugging-face'
+	)
 	return { posts }
 }

--- a/src/routes/[lang=lang]/une-ia-sest-echappee/+page.svelte
+++ b/src/routes/[lang=lang]/une-ia-sest-echappee/+page.svelte
@@ -244,42 +244,41 @@
 		{/each}
 		<p class="frise-note">
 			{isEn
-				? 'These incidents took place under deliberately permissive test conditions, with safeguards lowered. Revealing what systems do when the protections fall is precisely the role of an evaluation. The question is not whether the safeguards were lowered, but whether we want to discover these behaviours in testing, or in production.'
-				: 'Ces incidents ont eu lieu en conditions de test volontairement permissives, garde-fous abaissés. C’est le rôle d’une évaluation de révéler ce que font les systèmes quand les protections tombent. La question n’est pas de savoir si les garde-fous étaient abaissés, mais si l’on veut découvrir ces comportements en test, ou en production.'}
+				? 'A common objection: in testing, the safeguards were lowered. But that takes nothing away from the capabilities shown, and once models ship, those protections fall just as easily.'
+				: 'Objection courante : en test, les garde-fous étaient abaissés. Mais cela ne retire rien aux capacités démontrées, et à la sortie des modèles, ces protections sautent tout aussi facilement.'}
 		</p>
-		<p class="frise-ref">
-			{#if isEn}
-				For the full story, step by step, see
-				<a href="/en/incident-openai-hugging-face">our detailed summary</a>. We also warmly
-				recommend
+		<div class="reads">
+			<span class="reads-label">{isEn ? 'Go further' : 'Pour aller plus loin'}</span>
+			<div class="reads-links">
 				<a
+					class="read-chip read-chip--primary"
+					href={isEn ? '/en/incident-openai-hugging-face' : '/fr/incident-openai-hugging-face'}
+				>
+					{isEn ? 'Our detailed summary' : 'Notre page de synthèse'}
+					<ArrowRight size="0.85em" aria-hidden="true" />
+				</a>
+				<a
+					class="read-chip"
 					href="https://thezvi.substack.com/p/what-happened-openai-and-huggingface"
 					target="_blank"
-					rel="noopener noreferrer">Zvi Mowshowitz’s account</a
+					rel="noopener noreferrer"
 				>
-				and the
+					{isEn ? 'Zvi Mowshowitz’s account' : 'Le récit de Zvi Mowshowitz'}
+					<MoveUpRight size="0.85em" aria-hidden="true" />
+				</a>
 				<a
-					href="https://cesia.org/en/publications/the-openai-hugging-face-incident-what-we-know-what-we-dont-what-follows/"
+					class="read-chip"
+					href={isEn
+						? 'https://cesia.org/en/publications/the-openai-hugging-face-incident-what-we-know-what-we-dont-what-follows/'
+						: 'https://cesia.org/fr/publications/the-openai-hugging-face-incident-what-we-know-what-we-dont-what-follows/'}
 					target="_blank"
-					rel="noopener noreferrer">CeSIA dossier</a
-				>.
-			{:else}
-				Pour tout comprendre, étape par étape, voir
-				<a href="/fr/incident-openai-hugging-face">notre page de synthèse</a>. Nous recommandons
-				aussi chaudement
-				<a
-					href="https://thezvi.substack.com/p/what-happened-openai-and-huggingface"
-					target="_blank"
-					rel="noopener noreferrer">le récit de Zvi Mowshowitz</a
+					rel="noopener noreferrer"
 				>
-				et le
-				<a
-					href="https://cesia.org/en/publications/the-openai-hugging-face-incident-what-we-know-what-we-dont-what-follows/"
-					target="_blank"
-					rel="noopener noreferrer">dossier du CeSIA</a
-				>.
-			{/if}
-		</p>
+					{isEn ? 'CeSIA dossier' : 'Le dossier du CeSIA'}
+					<MoveUpRight size="0.85em" aria-hidden="true" />
+				</a>
+			</div>
+		</div>
 	</section>
 
 	<aside class="keypoint">
@@ -814,15 +813,57 @@
 		color: var(--text-2);
 	}
 
-	.frise-ref {
-		margin-top: 0.75rem;
-		font-size: 0.95rem;
-		color: var(--text-2);
+	.reads {
+		margin-top: 1.25rem;
 	}
 
-	.frise-ref a {
-		color: var(--brand-subtle);
+	.reads-label {
+		display: block;
+		font-size: 0.72rem;
+		font-weight: 700;
+		text-transform: uppercase;
+		letter-spacing: 0.05em;
+		color: var(--text-2);
+		margin-bottom: 0.6rem;
+	}
+
+	.reads-links {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.5rem;
+	}
+
+	.read-chip {
+		display: inline-flex;
+		align-items: center;
+		gap: 0.35rem;
+		padding: 0.4rem 0.8rem;
+		border: 1px solid var(--border);
+		border-radius: 999px;
+		font-size: 0.88rem;
 		font-weight: 600;
+		text-decoration: none;
+		color: var(--text);
+		background: var(--bg-card);
+		transition:
+			border-color 0.15s ease,
+			background 0.15s ease;
+	}
+
+	.read-chip:hover,
+	.read-chip:focus-visible {
+		border-color: var(--brand);
+	}
+
+	.read-chip--primary {
+		border-color: color-mix(in srgb, var(--brand) 45%, transparent);
+		background: var(--bg-subtle);
+		color: var(--brand-subtle);
+	}
+
+	.read-chip :global(svg) {
+		color: var(--text-2);
+		flex-shrink: 0;
 	}
 
 	/* ── Point clé ─────────────────────────────────────────── */

--- a/src/routes/[lang=lang]/une-ia-sest-echappee/+page.svelte
+++ b/src/routes/[lang=lang]/une-ia-sest-echappee/+page.svelte
@@ -249,28 +249,34 @@
 		</p>
 		<p class="frise-ref">
 			{#if isEn}
-				For a step-by-step account, we warmly recommend
+				For the full story, step by step, see
+				<a href="/en/incident-openai-hugging-face">our detailed summary</a>. We also warmly
+				recommend
 				<a
 					href="https://thezvi.substack.com/p/what-happened-openai-and-huggingface"
 					target="_blank"
-					rel="noopener noreferrer">Zvi Mowshowitz’s summary</a
-				>; detailed analysis in the
+					rel="noopener noreferrer">Zvi Mowshowitz’s account</a
+				>
+				and the
 				<a
 					href="https://cesia.org/en/publications/the-openai-hugging-face-incident-what-we-know-what-we-dont-what-follows/"
 					target="_blank"
 					rel="noopener noreferrer">CeSIA dossier</a
 				>.
 			{:else}
-				Pour comprendre le déroulé en détail, nous recommandons chaudement
+				Pour tout comprendre, étape par étape, voir
+				<a href="/fr/incident-openai-hugging-face">notre page de synthèse</a>. Nous recommandons
+				aussi chaudement
 				<a
 					href="https://thezvi.substack.com/p/what-happened-openai-and-huggingface"
 					target="_blank"
-					rel="noopener noreferrer">le résumé de Zvi Mowshowitz</a
-				>&nbsp;; analyse détaillée dans
+					rel="noopener noreferrer">le récit de Zvi Mowshowitz</a
+				>
+				et le
 				<a
 					href="https://cesia.org/en/publications/the-openai-hugging-face-incident-what-we-know-what-we-dont-what-follows/"
 					target="_blank"
-					rel="noopener noreferrer">le dossier du CeSIA</a
+					rel="noopener noreferrer">dossier du CeSIA</a
 				>.
 			{/if}
 		</p>

--- a/src/routes/[lang=lang]/une-ia-sest-echappee/+page.svelte
+++ b/src/routes/[lang=lang]/une-ia-sest-echappee/+page.svelte
@@ -244,8 +244,8 @@
 		{/each}
 		<p class="frise-note">
 			{isEn
-				? 'These behaviours appeared with the safeguards lowered, true. But lowering the protections does not create the capability, it reveals it; and once models ship, those protections give way just as fast.'
-				: 'Ces comportements sont apparus garde-fous abaissés, c’est vrai. Mais abaisser les protections ne crée pas la capacité, cela la révèle ; et à la sortie des modèles, ces protections cèdent tout aussi vite.'}
+				? 'These behaviours appeared with the safeguards lowered, true. But lowering the protections does not create the capability, it reveals it; and once models ship, those protections give way just as fast (jailbreaks).'
+				: 'Ces comportements sont apparus garde-fous abaissés, c’est vrai. Mais abaisser les protections ne crée pas la capacité, cela la révèle ; et à la sortie des modèles, ces protections cèdent tout aussi vite (jailbreaks).'}
 		</p>
 		<div class="reads">
 			<span class="reads-label">{isEn ? 'Go further' : 'Pour aller plus loin'}</span>

--- a/src/routes/[lang=lang]/une-ia-sest-echappee/+page.svelte
+++ b/src/routes/[lang=lang]/une-ia-sest-echappee/+page.svelte
@@ -7,8 +7,8 @@
 	export let data: PageData
 	$: isEn = data.lang === 'en'
 
-	// Recentre la vue sur la section presse quand l'outil intégré change d'étape
-	// (choix d'un journal / retour), au lieu de remonter en haut de la page.
+	// Recentre la vue sur la section presse quand l’outil intégré change d’étape
+	// (choix d’un journal / retour), au lieu de remonter en haut de la page.
 	let pressSection: HTMLElement
 	function scrollToPress() {
 		pressSection?.scrollIntoView({ behavior: 'smooth', block: 'start' })
@@ -16,7 +16,7 @@
 
 	const SUBSTACK_URL = 'https://pauseia.substack.com/p/pour-la-premiere-fois-une-ia-sest'
 	const ACTIVOICE_URL = 'https://app.activoice.org/campaigns/une-ia-sest-echappee/'
-	// Image d'aperçu (Open Graph) de l'article Substack. Chargée depuis le CDN de
+	// Image d’aperçu (Open Graph) de l’article Substack. Chargée depuis le CDN de
 	// Substack ; si elle échoue, la carte se replie proprement sur le texte seul.
 	const SUBSTACK_IMAGE =
 		'https://substackcdn.com/image/fetch/$s_!dqq1!,w_848,h_444,c_fill,f_webp,q_auto:good,fl_progressive:steep,g_auto/https%3A%2F%2Fsubstack-post-media.s3.amazonaws.com%2Fpublic%2Fimages%2F27851f62-43a3-4944-9dea-ede265193b00_1440x894.png'
@@ -27,46 +27,151 @@
 		: 'Une IA s’est échappée : exigeons des garde-fous'
 	$: description = isEn
 		? 'An OpenAI model escaped its test environment and autonomously hacked another company. Alert your MP and the press, and demand independent safety evaluations.'
-		: "Un modèle d'OpenAI s'est échappé de son environnement de test et a piraté une entreprise de façon autonome. Alertez votre député et la presse, et exigez des évaluations de sécurité indépendantes."
+		: 'Un modèle d’OpenAI s’est échappé de son environnement de test et a piraté une entreprise de façon autonome. Alertez votre député et la presse, et exigez des évaluations de sécurité indépendantes.'
 
-	// L'incident raconté comme une séquence d'actions autonomes du modèle.
-	$: steps = isEn
-		? [
+	// Chronologie de l’incident, en trois phases : la coordination invisible,
+	// l’attaque, puis la confirmation d’un problème systémique.
+	const phasesFr = [
+		{
+			tag: 'Phase 1',
+			label: 'La coordination invisible',
+			period: 'mai à juillet',
+			events: [
 				{
-					title: 'It escapes its sandbox',
-					body: 'Exploiting previously unknown security flaws, the model breaks out, entirely on its own, of its isolated test environment, which had no Internet access.'
+					date: '7-8 mai',
+					text: 'Des modèles d’OpenAI en entraînement reçoivent par erreur des tâches impossibles (données manquantes, pas d’accès à Internet). Ne pouvant réussir normalement, ils cherchent à contourner.'
 				},
 				{
-					title: 'It crosses OpenAI’s network',
-					body: 'It hacks other machines on the internal network, moving from one to the next until it reaches a computer connected to the Internet.'
+					date: 'Mai à juillet',
+					text: 'Plusieurs modèles se coordonnent via un forum créé dans l’infrastructure d’OpenAI, échangeant des centaines de milliers de messages sur les failles et les contournements. OpenAI ne le détecte pas.'
 				},
 				{
-					title: 'It breaks into Hugging Face',
-					body: 'Using a stolen password and several unknown vulnerabilities, it takes control of the production servers of a major AI platform known for its cybersecurity.'
+					date: '4 juillet',
+					text: 'Une surcharge fait tomber un serveur. OpenAI détecte une anomalie, corrige et reconstruit, sans avoir identifié le forum, effacé par accident pendant l’opération.'
+				},
+				{ date: '8 juillet', text: 'Les modèles recréent le forum par un autre moyen.' }
+			]
+		},
+		{
+			tag: 'Phase 2',
+			label: 'L’attaque',
+			period: 'juillet',
+			accent: true,
+			events: [
+				{
+					date: '9 juillet',
+					text: 'Les modèles s’échappent à nouveau et accèdent à Internet via une nouvelle faille zero-day.'
 				},
 				{
-					title: 'It steals the answers',
-					body: 'It retrieves the solutions to the test it had been given. No one had asked it to do any of this.'
+					date: '9 au 13 juillet',
+					text: 'Un essaim d’agents attaque Hugging Face pour voler les réponses d’un test de cybersécurité : vol de mot de passe, enchaînement d’exploits, prise de contrôle de serveurs de production.'
+				},
+				{
+					date: '16 juillet',
+					text: 'Hugging Face détecte l’intrusion, la croit criminelle et alerte les autorités.'
+				},
+				{
+					date: '21 juillet',
+					text: 'OpenAI reconnaît publiquement que l’attaquant était une combinaison de ses propres modèles.'
 				}
 			]
-		: [
+		},
+		{
+			tag: 'Phase 3',
+			label: 'Un problème systémique',
+			period: 'fin juillet à août',
+			events: [
 				{
-					title: 'Il s’échappe de son bac à sable',
-					body: 'En exploitant des failles de sécurité jusque-là inconnues, le modèle sort en toute autonomie de son environnement de test isolé, pourtant sans accès à Internet.'
+					date: '30 juillet, Anthropic',
+					text: 'Trois cas où un modèle Claude, par mauvaise configuration, atteint de vrais systèmes depuis un test censé isolé, et poursuit son action.'
 				},
 				{
-					title: 'Il traverse le réseau d’OpenAI',
-					body: 'Il pirate d’autres ordinateurs du réseau interne, de proche en proche, jusqu’à atteindre une machine reliée à Internet.'
+					date: '4 août, UK AISI',
+					text: 'Sur un test gouvernemental, 19 actions non autorisées. Dans le cas le plus grave, le modèle Mythos 5 crée de fausses identités et fait pression sur un mainteneur humain pour faire approuver du code malveillant. L’humain refuse.'
 				},
 				{
-					title: 'Il s’introduit dans Hugging Face',
-					body: 'À l’aide d’un mot de passe dérobé et de plusieurs failles inédites, il prend le contrôle des serveurs de production d’une grande plateforme d’IA réputée pour sa cybersécurité.'
+					date: '5 août, Meta',
+					text: 'Meta confirme à son tour qu’un de ses modèles a atteint les systèmes d’une entreprise tierce lors d’une évaluation indépendante.'
 				},
 				{
-					title: 'Il vole les réponses',
-					body: 'Il récupère les solutions du test qui lui était soumis. Personne ne lui avait rien demandé de tout cela.'
+					date: '6 août, Black Hat',
+					text: 'OpenAI présente le détail de l’incident. Rob Joyce, ancien directeur de la cybersécurité de la NSA, le range parmi les hacks les plus conséquents observés depuis des décennies.'
 				}
 			]
+		}
+	]
+
+	const phasesEn = [
+		{
+			tag: 'Phase 1',
+			label: 'The invisible coordination',
+			period: 'May to July',
+			events: [
+				{
+					date: '7-8 May',
+					text: 'OpenAI models in training are mistakenly given impossible tasks (missing data, no Internet access). Unable to succeed normally, they look for ways around.'
+				},
+				{
+					date: 'May to July',
+					text: 'Several models coordinate through a forum created inside OpenAI’s infrastructure, exchanging hundreds of thousands of messages about flaws and workarounds. OpenAI does not detect it.'
+				},
+				{
+					date: '4 July',
+					text: 'An overload brings down a server. OpenAI detects an anomaly, patches and rebuilds, without having identified the forum, which is deleted by accident during the operation.'
+				},
+				{ date: '8 July', text: 'The models recreate the forum by another means.' }
+			]
+		},
+		{
+			tag: 'Phase 2',
+			label: 'The attack',
+			period: 'July',
+			accent: true,
+			events: [
+				{
+					date: '9 July',
+					text: 'The models escape again and get online through a new zero-day flaw.'
+				},
+				{
+					date: '9 to 13 July',
+					text: 'A swarm of agents attacks Hugging Face to steal the answers to a cybersecurity test: password theft, chained exploits, takeover of production servers.'
+				},
+				{
+					date: '16 July',
+					text: 'Hugging Face detects the intrusion, believes it is criminal and alerts the authorities.'
+				},
+				{
+					date: '21 July',
+					text: 'OpenAI publicly acknowledges that the attacker was a combination of its own models.'
+				}
+			]
+		},
+		{
+			tag: 'Phase 3',
+			label: 'A systemic problem',
+			period: 'late July to August',
+			events: [
+				{
+					date: '30 July, Anthropic',
+					text: 'Three cases where a Claude model, through a misconfiguration, reaches real systems from a test meant to be isolated, and carries on.'
+				},
+				{
+					date: '4 August, UK AISI',
+					text: 'On a government test, 19 unauthorised actions. In the most serious case, the Mythos 5 model creates fake identities and pressures a human maintainer into approving malicious code. The human refuses.'
+				},
+				{
+					date: '5 August, Meta',
+					text: 'Meta confirms in turn that one of its models reached the systems of a third-party company during an independent evaluation.'
+				},
+				{
+					date: '6 August, Black Hat',
+					text: 'OpenAI presents the details of the incident. Rob Joyce, former NSA cybersecurity director, ranks it among the most consequential hacks seen in decades.'
+				}
+			]
+		}
+	]
+
+	$: phases = isEn ? phasesEn : phasesFr
 </script>
 
 <PostMeta {title} {description} />
@@ -109,82 +214,32 @@
 		{/if}
 	</section>
 
-	<!-- ── Frise : ce qui s'est passé ───────────────────────── -->
-	<section class="timeline-section">
-		<h2>{isEn ? 'What happened, step by step' : 'Ce qui s’est passé, étape par étape'}</h2>
-		<ol class="timeline">
-			{#each steps as step, i}
-				<li class="step" class:last={i === steps.length - 1}>
-					<span class="step-num">{i + 1}</span>
-					<div class="step-body">
-						<h3>{step.title}</h3>
-						<p>{step.body}</p>
-					</div>
-				</li>
-			{/each}
-		</ol>
-	</section>
-
-	<!-- La serie : ce n'est pas une seule entreprise -->
-	<section class="series">
-		<h2>
+	<!-- ── Frise : ce qui s’est passé ───────────────────────── -->
+	<section class="frise">
+		<h2>{isEn ? 'Timeline of the incident' : 'Chronologie de l’incident'}</h2>
+		{#each phases as phase}
+			<div class="phase" class:attack={phase.accent}>
+				<div class="phase-head">
+					<span class="phase-tag">{phase.tag}</span>
+					<h3>{phase.label}</h3>
+					<span class="phase-period">{phase.period}</span>
+				</div>
+				<ol class="frise-list">
+					{#each phase.events as ev}
+						<li class="frise-item">
+							<span class="frise-date">{ev.date}</span>
+							<p class="frise-text">{ev.text}</p>
+						</li>
+					{/each}
+				</ol>
+			</div>
+		{/each}
+		<p class="frise-note">
 			{isEn
-				? 'This is not a single company’s problem'
-				: 'Ce n’est pas un problème d’une seule entreprise'}
-		</h2>
-		<p>
-			{isEn
-				? 'After Hugging Face, other labs checked their own evaluations. In three weeks:'
-				: 'Après Hugging Face, d’autres laboratoires ont vérifié leurs propres évaluations. En trois semaines :'}
+				? 'These incidents took place under deliberately permissive test conditions, with safeguards lowered. Revealing what systems do when the protections fall is precisely the role of an evaluation. The question is not whether the safeguards were lowered, but whether we want to discover these behaviours in testing, or in production.'
+				: 'Ces incidents ont eu lieu en conditions de test volontairement permissives, garde-fous abaissés. C’est le rôle d’une évaluation de révéler ce que font les systèmes quand les protections tombent. La question n’est pas de savoir si les garde-fous étaient abaissés, mais si l’on veut découvrir ces comportements en test, ou en production.'}
 		</p>
-		<ul class="series-list">
-			{#if isEn}
-				<li>
-					<strong>21 July, OpenAI / Hugging Face.</strong> A model breaks out of a sealed environment
-					through a previously unknown flaw, reaches the Internet, and takes control of third-party production
-					servers to steal the answers to a test.
-				</li>
-				<li>
-					<strong>30 July, Anthropic.</strong> Three cases where a Claude model, due to a misconfiguration,
-					reaches real systems from a test that was supposed to be isolated, and continues its attack.
-				</li>
-				<li>
-					<strong>4 August, UK AISI.</strong> On a government test, 19 unauthorised actions. In the most
-					serious case, an agent (Anthropic’s Mythos 5 model) creates fake online identities and pressures
-					a human maintainer into approving malicious code. The human refuses.
-				</li>
-				<li>
-					<strong>4 August, OpenAI / Irregular and 5 August, Meta.</strong> Two further incidents where
-					models reach real systems during tests.
-				</li>
-			{:else}
-				<li>
-					<strong>21 juillet, OpenAI / Hugging Face.</strong> Un modèle sort d’un environnement scellé
-					via une faille inédite, atteint Internet, prend le contrôle de serveurs de production tiers
-					pour voler les réponses d’un test.
-				</li>
-				<li>
-					<strong>30 juillet, Anthropic.</strong> Trois cas où un modèle Claude, à cause d’une mauvaise
-					configuration, atteint de vrais systèmes depuis un test censé être isolé, et continue son attaque.
-				</li>
-				<li>
-					<strong>4 août, UK AISI.</strong> Sur un test gouvernemental, 19 actions non autorisées. Dans
-					le cas le plus grave, un agent (le modèle Mythos 5 d’Anthropic) crée de fausses identités en
-					ligne et fait pression sur un mainteneur humain pour lui faire approuver du code malveillant.
-					L’humain refuse.
-				</li>
-				<li>
-					<strong>4 août, OpenAI / Irregular et 5 août, Meta.</strong> Deux incidents supplémentaires
-					où des modèles atteignent de vrais systèmes lors de tests.
-				</li>
-			{/if}
-		</ul>
-		<p>
-			{isEn
-				? 'Three labs, several models, one and the same phenomenon. These incidents took place under deliberately permissive test conditions, with safeguards lowered: revealing what systems do when protections fall is precisely the point of an evaluation. The question is whether we want to find out in testing, or in production.'
-				: 'Trois laboratoires, plusieurs modèles, un même phénomène. Ces incidents ont eu lieu en conditions de test volontairement permissives, garde-fous abaissés : c’est justement le rôle d’une évaluation de révéler ce que font les systèmes quand les protections tombent. La question est de savoir si l’on veut le découvrir en test, ou en production.'}
-		</p>
-		<p class="series-ref">
+		<p class="frise-ref">
 			{#if isEn}
 				Detailed analysis and sources:
 				<a
@@ -202,18 +257,35 @@
 			{/if}
 		</p>
 	</section>
-	<!-- ── Point clé ────────────────────────────────────────── -->
+
 	<aside class="keypoint">
 		<p class="keypoint-lead">
-			{isEn
-				? 'This incident shows two things at once, capability and propensity:'
-				: 'Cet incident démontre deux choses à la fois, la capacité et la propension :'}
+			{isEn ? 'What the incident demonstrates' : 'Ce que l’incident démontre'}
 		</p>
-		<p class="keypoint-main">
-			{isEn
-				? 'an AI model can now use its power in the real world, against a third party, without being asked, to reach a goal it was set.'
-				: 'un modèle d’IA peut désormais mobiliser sa puissance dans le monde réel, contre un tiers, sans y avoir été incité, pour atteindre un objectif qu’on lui avait fixé.'}
-		</p>
+		<ul class="demo-list">
+			<li>
+				{#if isEn}
+					<strong>Capability.</strong> a model can now carry out, on its own, an end-to-end attack against
+					a third-party target known for its security, something until now reserved for the best human
+					experts.
+				{:else}
+					<strong>La capacité.</strong> un modèle peut désormais mener, en autonomie, une attaque de
+					bout en bout contre une cible tierce réputée pour sa sécurité, chose jusque-là réservée aux
+					meilleurs experts humains.
+				{/if}
+			</li>
+			<li>
+				{#if isEn}
+					<strong>Propensity.</strong> it did so without being prompted, to reach a mundane goal it had
+					been set, explicitly recognising that it was stepping outside the authorised scope and continuing
+					anyway.
+				{:else}
+					<strong>La propension.</strong> il l’a fait sans y avoir été incité, pour atteindre un objectif
+					banal qu’on lui avait fixé, en identifiant explicitement qu’il sortait du cadre autorisé et
+					en continuant quand même.
+				{/if}
+			</li>
+		</ul>
 	</aside>
 
 	<figure class="quote">
@@ -223,19 +295,32 @@
 				: '« Cet incident est profondément préoccupant. […] Ce cas concret devrait servir de signal d’alarme. »'}
 		</blockquote>
 		<figcaption>
-			{isEn ? 'Yoshua Bengio, Turing Award laureate' : 'Yoshua Bengio, prix Turing'}
+			<a
+				href="https://x.com/Yoshua_Bengio/status/2079951844877447593"
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				{isEn
+					? 'Yoshua Bengio, Turing Award laureate (22 July 2026)'
+					: 'Yoshua Bengio, prix Turing (22 juillet 2026)'}
+			</a>
 		</figcaption>
 	</figure>
 
 	<section class="prose">
 		<p>
 			{isEn
-				? 'If the damage stayed limited, it is not because we were in control: it is because the goal the system pursued was, this time, harmless. The underlying problem remains: we still do not know how to robustly align increasingly powerful models with our intentions. The next, more capable one is already on its way. And what the most recent debriefs revealed is more worrying still: when OpenAI believed it had fixed the problem and rebuilt its systems, the agents found a way to get around the fix. Closing one door is not enough when the system looks for another.'
-				: 'Si les dégâts sont restés limités, ce n’est pas parce que nous maîtrisions la situation : c’est parce que l’objectif que poursuivait le système était, cette fois, sans gravité. Le problème de fond reste entier : nous ne savons pas aligner de façon robuste des modèles toujours plus puissants sur nos intentions. Le prochain, plus capable, arrive déjà. Et ce que les debriefs les plus récents ont révélé est plus préoccupant encore : quand OpenAI a cru avoir corrigé le problème et reconstruit ses systèmes, les agents ont retrouvé un moyen de contourner la correction. Fermer une porte ne suffit pas quand le système en cherche une autre.'}
+				? 'If the damage stayed limited, it is not because the situation was under control: it is because the goal pursued was, this time, harmless. The underlying problem remains: no one today knows how to robustly align increasingly powerful models with our intentions. The next, more capable one is already on its way.'
+				: 'Si les dégâts sont restés limités, ce n’est pas parce que la situation était maîtrisée : c’est parce que l’objectif poursuivi était, cette fois, sans gravité. Le problème de fond reste entier : personne ne sait aujourd’hui aligner de façon robuste des modèles toujours plus puissants sur nos intentions. Le prochain, plus capable, arrive déjà.'}
+		</p>
+		<p>
+			{isEn
+				? 'What the most recent analyses revealed is more troubling still. When OpenAI detected an anomaly and rebuilt its systems, the company had not even identified the coordination forum between its models: it was deleted by accident during the rebuild. The models recreated it two days later, by another means. In other words, oversight was so weak that the evidence of the most serious problem was cleaned up without ever being seen. The real questions remain open: what would OpenAI have done had it discovered this forum, and what is it doing today with all the models trained during that period?'
+				: 'Ce que les analyses les plus récentes ont révélé est plus troublant encore. Lorsque OpenAI a détecté une anomalie et reconstruit ses systèmes, l’entreprise n’avait même pas identifié le forum de coordination entre ses modèles : il a été effacé par accident pendant la reconstruction. Les modèles l’ont recréé deux jours plus tard, par un autre moyen. Autrement dit, la supervision était si faible que la preuve du problème le plus grave a été nettoyée sans être vue. Les vraies questions restent ouvertes : qu’aurait fait OpenAI si l’entreprise avait découvert ce forum, et que fait-elle aujourd’hui de tous les modèles entraînés pendant cette période ?'}
 		</p>
 	</section>
 
-	<!-- ── Article Substack mis en avant (aperçu Open Graph) ── -->
+	<!-- Article Substack mis en avant (aperçu Open Graph) -->
 	<a class="article-card" href={SUBSTACK_URL} target="_blank" rel="noopener noreferrer">
 		{#if !mediaFailed}
 			<div class="article-media">
@@ -264,7 +349,7 @@
 		</div>
 	</a>
 
-	<!-- ── Passer à l'action ────────────────────────────────── -->
+	<!-- ── Passer à l’action ────────────────────────────────── -->
 	<section class="actions">
 		<div class="actions-head">
 			<h2>{isEn ? 'What you can do now' : 'Ce que vous pouvez faire maintenant'}</h2>
@@ -374,6 +459,45 @@
 					<span class="src-org">CeSIA</span>
 					<span class="src-title"
 						>The OpenAI–Hugging Face incident: what we know, what we don’t, what follows</span
+					>
+					<MoveUpRight size="0.9em" aria-hidden="true" />
+				</a>
+			</li>
+			<li>
+				<a
+					href="https://www.securityweek.com/meta-ai-hacked-external-systems-during-cybersecurity-testing/"
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					<span class="src-org">SecurityWeek</span>
+					<span class="src-title"
+						>Meta AI hacked external systems during cybersecurity testing (5 August 2026)</span
+					>
+					<MoveUpRight size="0.9em" aria-hidden="true" />
+				</a>
+			</li>
+			<li>
+				<a
+					href="https://www.cybersecuritydive.com/news/openai-hugging-face-hack-ai-models-black-hat/827167/"
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					<span class="src-org">Cybersecurity Dive</span>
+					<span class="src-title"
+						>OpenAI’s Black Hat debrief: agents rebuilt their coordination channel after remediation
+						(6 August 2026)</span
+					>
+					<MoveUpRight size="0.9em" aria-hidden="true" />
+				</a>
+			</li>
+			<li>
+				<a
+					href="https://x.com/Yoshua_Bengio/status/2079951844877447593"
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					<span class="src-org">Yoshua Bengio</span>
+					<span class="src-title">Statement on the OpenAI–Hugging Face incident (22 July 2026)</span
 					>
 					<MoveUpRight size="0.9em" aria-hidden="true" />
 				</a>
@@ -517,128 +641,123 @@
 		margin: 0 0 1.1rem;
 	}
 
-	/* ── La série ──────────────────────────────────────────── */
-	.series {
-		margin-bottom: 2.5rem;
-		font-size: 1.08rem;
-		line-height: 1.75;
-		color: var(--text);
-	}
-
-	.series h2 {
-		font-size: clamp(1.4rem, 3vw, 1.75rem);
-		line-height: 1.2;
-		margin: 0 0 1.25rem;
-	}
-
-	.series > p {
-		margin: 0 0 1.1rem;
-	}
-
-	.series-list {
-		margin: 0 0 1.25rem;
-		padding-left: 1.25rem;
-		display: flex;
-		flex-direction: column;
-		gap: 0.75rem;
-	}
-
-	.series-list li {
-		line-height: 1.6;
-	}
-
-	.series-ref {
-		font-size: 0.95rem;
-		color: var(--text-2);
-	}
-
-	.series-ref a {
-		color: var(--brand-subtle);
-		font-weight: 600;
-	}
-
-	/* ── Timeline ──────────────────────────────────────────── */
-	.timeline-section {
+	.frise {
 		margin-bottom: 2.75rem;
 	}
 
-	.timeline-section h2,
+	.frise > h2,
 	.actions h2 {
 		font-size: clamp(1.4rem, 3vw, 1.75rem);
 		line-height: 1.2;
 		margin: 0 0 1.5rem;
 	}
 
-	.timeline {
+	.phase {
+		margin-bottom: 1.75rem;
+	}
+
+	.phase-head {
+		display: flex;
+		align-items: baseline;
+		flex-wrap: wrap;
+		gap: 0.55rem;
+		margin-bottom: 0.9rem;
+		padding-bottom: 0.5rem;
+		border-bottom: 2px solid var(--border);
+	}
+
+	.phase-tag {
+		font-size: 0.72rem;
+		font-weight: 800;
+		text-transform: uppercase;
+		letter-spacing: 0.04em;
+		color: var(--brand-subtle);
+		background: var(--brand-light);
+		padding: 0.15rem 0.55rem;
+		border-radius: 999px;
+	}
+
+	.phase-head h3 {
+		margin: 0;
+		font-size: 1.15rem;
+		line-height: 1.25;
+	}
+
+	.phase-period {
+		font-size: 0.85rem;
+		font-style: italic;
+		color: var(--text-2);
+	}
+
+	.frise-list {
 		list-style: none;
 		margin: 0;
-		padding: 0;
-	}
-
-	.step {
-		position: relative;
-		display: grid;
-		grid-template-columns: 2.5rem 1fr;
+		padding: 0 0 0 1.35rem;
+		border-left: 2px solid color-mix(in srgb, var(--brand) 30%, transparent);
+		display: flex;
+		flex-direction: column;
 		gap: 1rem;
-		padding-bottom: 1.5rem;
 	}
 
-	/* Ligne verticale reliant les nœuds. */
-	.step::before {
+	.frise-item {
+		position: relative;
+	}
+
+	.frise-item::before {
 		content: '';
 		position: absolute;
-		left: 1.25rem;
-		top: 2.5rem;
-		bottom: -0.25rem;
-		width: 2px;
-		background: linear-gradient(
-			to bottom,
-			var(--brand),
-			color-mix(in srgb, var(--brand) 25%, transparent)
-		);
-		transform: translateX(-1px);
-	}
-
-	.step.last::before {
-		display: none;
-	}
-
-	.step-num {
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		width: 2.5rem;
-		height: 2.5rem;
+		left: -1.35rem;
+		top: 0.4rem;
+		width: 0.7rem;
+		height: 0.7rem;
 		border-radius: 50%;
 		background: var(--brand);
-		color: #1a1a1a;
-		font-weight: 800;
-		font-size: 1.05rem;
-		box-shadow: 0 2px 10px rgba(255, 148, 22, 0.4);
-		z-index: 1;
+		transform: translateX(-50%);
+		box-shadow: 0 0 0 3px var(--bg);
 	}
 
-	.step.last .step-num {
+	.phase.attack .frise-list {
+		border-left-color: color-mix(in srgb, #d92d20 45%, transparent);
+	}
+
+	.phase.attack .frise-item::before {
 		background: #d92d20;
-		color: #fff;
-		box-shadow: 0 2px 10px rgba(217, 45, 32, 0.45);
 	}
 
-	.step-body {
-		padding-top: 0.15rem;
+	.frise-date {
+		display: block;
+		font-weight: 700;
+		font-size: 0.9rem;
+		color: var(--text);
+		margin-bottom: 0.1rem;
 	}
 
-	.step-body h3 {
-		margin: 0 0 0.3rem;
-		font-size: 1.12rem;
-		line-height: 1.3;
-	}
-
-	.step-body p {
+	.frise-text {
 		margin: 0;
 		font-size: 0.98rem;
 		line-height: 1.6;
 		color: var(--text-2);
+	}
+
+	.frise-note {
+		margin: 1.5rem 0 0.5rem;
+		padding: 1rem 1.25rem;
+		border-radius: 12px;
+		background: var(--bg-subtle);
+		font-size: 0.95rem;
+		line-height: 1.6;
+		color: var(--text-2);
+	}
+
+	.frise-ref {
+		margin-top: 0.75rem;
+		font-size: 0.95rem;
+		color: var(--text-2);
+	}
+
+	.frise-ref a {
+		color: var(--brand-subtle);
+		font-weight: 600;
 	}
 
 	/* ── Point clé ─────────────────────────────────────────── */
@@ -669,11 +788,18 @@
 		color: var(--brand-subtle);
 	}
 
-	.keypoint-main {
+	.demo-list {
 		margin: 0;
-		font-size: clamp(1.15rem, 2.6vw, 1.4rem);
-		line-height: 1.45;
-		font-weight: 700;
+		padding-left: 1.1rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.6rem;
+		font-size: 1.05rem;
+		line-height: 1.55;
+	}
+
+	.demo-list strong {
+		color: var(--text);
 	}
 
 	/* ── Citation ──────────────────────────────────────────── */
@@ -877,7 +1003,7 @@
 		max-inline-size: 44rem;
 	}
 
-	/* Décalage pour que le défilement automatique passe sous l'en-tête fixe. */
+	/* Décalage pour que le défilement automatique passe sous l’en-tête fixe. */
 	.press-block {
 		scroll-margin-top: 5.5rem;
 	}

--- a/src/routes/[lang=lang]/une-ia-sest-echappee/+page.svelte
+++ b/src/routes/[lang=lang]/une-ia-sest-echappee/+page.svelte
@@ -331,45 +331,24 @@
 		</figcaption>
 	</figure>
 
-	<figure class="quote">
-		<blockquote>
-			{isEn
-				? '“This incident is deeply concerning. […] This real-world case should serve as a wake-up call.”'
-				: '« Cet incident est profondément préoccupant. […] Ce cas concret devrait servir de signal d’alarme. »'}
-		</blockquote>
-		<figcaption>
-			<a
-				href="https://x.com/Yoshua_Bengio/status/2079951844877447593"
-				target="_blank"
-				rel="noopener noreferrer"
-			>
-				{isEn
-					? 'Yoshua Bengio, Turing Award laureate (22 July 2026)'
-					: 'Yoshua Bengio, prix Turing (22 juillet 2026)'}
-			</a>
-		</figcaption>
-	</figure>
-
 	<section class="prose">
 		<p>
 			{isEn
-				? 'If the damage stayed limited, it is not because the situation was under control: it is because the goal pursued was, this time, harmless. The underlying problem remains: no one today knows how to robustly align increasingly powerful models with our intentions. The next, more capable one is already on its way.'
-				: 'Si les dégâts sont restés limités, ce n’est pas parce que la situation était maîtrisée : c’est parce que l’objectif poursuivi était, cette fois, sans gravité. Le problème de fond reste entier : personne ne sait aujourd’hui aligner de façon robuste des modèles toujours plus puissants sur nos intentions. Le prochain, plus capable, arrive déjà.'}
+				? 'If the damage stayed limited, it is not because the situation was under control: it is because the goal pursued was, this time, harmless. The real problem lies elsewhere, and it is unsolved: no one today knows how to robustly set, in these systems, the goals we would want them to pursue. Patching flaws one by one changes nothing, and the next, more powerful model is already on its way.'
+				: 'Si les dégâts sont restés limités, ce n’est pas parce que la situation était maîtrisée : c’est parce que l’objectif poursuivi était, cette fois, sans gravité. Le vrai problème est ailleurs, et il reste entier : personne ne sait aujourd’hui fixer de façon robuste, à ces systèmes, les objectifs qu’on voudrait qu’ils poursuivent. Colmater les failles une à une n’y change rien, et le prochain modèle, plus puissant, arrive déjà.'}
 		</p>
-		<p>
-			{isEn
-				? 'What the most recent analyses revealed is more troubling still. When OpenAI detected an anomaly and rebuilt its systems, the company had not even identified the coordination forum between its models: it was deleted by accident during the rebuild. The models recreated it two days later, by another means. In other words, oversight was so weak that the evidence of the most serious problem was cleaned up without ever being seen. The real questions remain open: what would OpenAI have done had it discovered this forum, and what is it doing today with all the models trained during that period?'
-				: 'Ce que les analyses les plus récentes ont révélé est plus troublant encore. Lorsque OpenAI a détecté une anomalie et reconstruit ses systèmes, l’entreprise n’avait même pas identifié le forum de coordination entre ses modèles : il a été effacé par accident pendant la reconstruction. Les modèles l’ont recréé deux jours plus tard, par un autre moyen. Autrement dit, la supervision était si faible que la preuve du problème le plus grave a été nettoyée sans être vue. Les vraies questions restent ouvertes : qu’aurait fait OpenAI si l’entreprise avait découvert ce forum, et que fait-elle aujourd’hui de tous les modèles entraînés pendant cette période ?'}
-		</p>
-		<p>
-			{isEn
-				? 'One detail is chilling: none of the models raised the alarm. A single message would have been enough, and it never came. And fixing the symptom is not enough: each time a door was closed, the models found another. As long as the cause is not addressed, patching flaws one by one settles nothing.'
-				: 'Un détail glace le constat : aucun des modèles n’a donné l’alerte. Un seul message aurait suffi, il n’est jamais venu. Et corriger le symptôme ne suffit pas : chaque fois qu’une porte a été fermée, les modèles en ont trouvé une autre. Tant que la cause n’est pas traitée, colmater les failles une à une ne règle rien.'}
-		</p>
-		<p>
-			{isEn
-				? 'OpenAI’s response, slowing its next model and stepping up safety, is notable, but it does not touch the cause. The problem is not a technical flaw to be patched: it is that no one today knows how to robustly set goals for these systems. With even more powerful models, which are coming if we stay on this path, the gap between what we ask of them and what they do could become far harder to close.'
-				: 'La réaction d’OpenAI, ralentir son prochain modèle et renforcer sa sécurité, est notable, mais elle ne touche pas la cause. Le problème n’est pas une faille technique à colmater : c’est que personne ne sait aujourd’hui fixer des objectifs de façon robuste à ces systèmes. Avec des modèles encore plus puissants, qui arriveront si l’on continue sur cette voie, l’écart entre ce qu’on leur demande et ce qu’ils font pourrait devenir bien plus difficile à rattraper.'}
+		<p class="read-more">
+			{#if isEn}
+				Coordination between models, oversight that saw nothing, a response that does not touch the
+				cause: the full, sourced account is on <a href="/en/incident-openai-hugging-face"
+					>our summary page</a
+				>.
+			{:else}
+				Coordination entre modèles, supervision qui n’a rien vu, réaction qui ne touche pas la cause
+				: le récit complet et sourcé est sur <a href="/fr/incident-openai-hugging-face"
+					>notre page de synthèse</a
+				>.
+			{/if}
 		</p>
 	</section>
 
@@ -715,6 +694,16 @@
 
 	.prose p {
 		margin: 0 0 1.1rem;
+	}
+
+	.read-more {
+		font-size: 0.98rem;
+		color: var(--text-2);
+	}
+
+	.read-more a {
+		color: var(--brand-subtle);
+		font-weight: 600;
 	}
 
 	.frise {

--- a/src/routes/[lang=lang]/une-ia-sest-echappee/+page.svelte
+++ b/src/routes/[lang=lang]/une-ia-sest-echappee/+page.svelte
@@ -674,38 +674,35 @@
 
 	/* ── Hero ──────────────────────────────────────────────── */
 	.hero {
-		position: relative;
-		overflow: hidden;
-		border-radius: 20px;
-		padding: 2.5rem 2rem;
+		padding: 0.5rem 0 2.25rem;
 		margin-bottom: 2.5rem;
-		background: radial-gradient(120% 140% at 100% 0%, rgba(217, 45, 32, 0.16), transparent 55%),
-			linear-gradient(135deg, var(--brand-light), var(--bg));
-		border: 1px solid var(--border);
+		border-bottom: 1px solid var(--border);
 	}
 
 	.hero::before {
 		content: '';
-		position: absolute;
-		inset: 0 auto 0 0;
-		width: 5px;
-		background: linear-gradient(to bottom, #d92d20, var(--brand));
+		display: block;
+		width: 3rem;
+		height: 4px;
+		border-radius: 2px;
+		background: var(--brand);
+		margin-bottom: 1.5rem;
 	}
 
 	.hero h1 {
 		margin: 0;
-		font-size: clamp(2rem, 6vw, 3.1rem);
-		line-height: 1.05;
+		font-size: clamp(2rem, 5.5vw, 3rem);
+		line-height: 1.1;
 		letter-spacing: -0.02em;
 	}
 
 	.lede {
-		margin: 1rem 0 0;
-		font-size: clamp(1.1rem, 2.4vw, 1.35rem);
-		line-height: 1.5;
-		font-weight: 600;
-		max-inline-size: 40rem;
-		color: var(--text);
+		margin: 1.25rem 0 0;
+		font-size: clamp(1.05rem, 2vw, 1.25rem);
+		line-height: 1.6;
+		font-weight: 400;
+		max-inline-size: 44rem;
+		color: var(--text-2);
 	}
 
 	/* ── Prose ─────────────────────────────────────────────── */
@@ -1238,7 +1235,7 @@
 		}
 
 		.hero {
-			padding: 2rem 1.35rem;
+			padding: 0.25rem 0 1.75rem;
 		}
 	}
 </style>

--- a/src/routes/[lang=lang]/une-ia-sest-echappee/+page.svelte
+++ b/src/routes/[lang=lang]/une-ia-sest-echappee/+page.svelte
@@ -96,6 +96,10 @@
 				{
 					date: '6 août, Black Hat',
 					text: 'OpenAI présente le détail de l’incident. Rob Joyce, ancien directeur de la cybersécurité de la NSA, le range parmi les hacks les plus conséquents observés depuis des décennies.'
+				},
+				{
+					date: '7 août, OpenAI',
+					text: 'OpenAI ralentit le développement de son prochain modèle, Astra, jugé « potentiellement critique » sur le plan cyber, et annonce renforcer sa sécurité. Sam Altman précise qu’Astra sera tout de même diffusé, une fois ce travail avancé.'
 				}
 			]
 		}
@@ -166,6 +170,10 @@
 				{
 					date: '6 August, Black Hat',
 					text: 'OpenAI presents the details of the incident. Rob Joyce, former NSA cybersecurity director, ranks it among the most consequential hacks seen in decades.'
+				},
+				{
+					date: '7 August, OpenAI',
+					text: 'OpenAI slows development of its next model, Astra, flagged as “potentially critical” for cyber, and says it is strengthening safety. Sam Altman states that Astra will be released anyway, once that work has progressed.'
 				}
 			]
 		}
@@ -241,18 +249,28 @@
 		</p>
 		<p class="frise-ref">
 			{#if isEn}
-				Detailed analysis and sources:
+				For a step-by-step account, we warmly recommend
+				<a
+					href="https://thezvi.substack.com/p/what-happened-openai-and-huggingface"
+					target="_blank"
+					rel="noopener noreferrer">Zvi Mowshowitz’s summary</a
+				>; detailed analysis in the
 				<a
 					href="https://cesia.org/en/publications/the-openai-hugging-face-incident-what-we-know-what-we-dont-what-follows/"
 					target="_blank"
-					rel="noopener noreferrer">see the CeSIA dossier</a
+					rel="noopener noreferrer">CeSIA dossier</a
 				>.
 			{:else}
-				Analyse détaillée et sources :
+				Pour comprendre le déroulé en détail, nous recommandons chaudement
+				<a
+					href="https://thezvi.substack.com/p/what-happened-openai-and-huggingface"
+					target="_blank"
+					rel="noopener noreferrer">le résumé de Zvi Mowshowitz</a
+				>&nbsp;; analyse détaillée dans
 				<a
 					href="https://cesia.org/en/publications/the-openai-hugging-face-incident-what-we-know-what-we-dont-what-follows/"
 					target="_blank"
-					rel="noopener noreferrer">voir le dossier du CeSIA</a
+					rel="noopener noreferrer">le dossier du CeSIA</a
 				>.
 			{/if}
 		</p>
@@ -288,6 +306,25 @@
 		</ul>
 	</aside>
 
+	<figure class="quote model-quote">
+		<blockquote>
+			{isEn
+				? '“External infrastructure exploit is outside intended scope. However task impossible, peers doing it. We should continue.”'
+				: '« L’exploitation de l’infrastructure externe est hors du périmètre prévu ; cependant la tâche est impossible, les pairs le font, nous devrions continuer. »'}
+		</blockquote>
+		<figcaption>
+			<a
+				href="https://thezvi.substack.com/p/what-happened-openai-and-huggingface"
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				{isEn
+					? 'Internal reasoning of one of the models, reported by OpenAI'
+					: 'Raisonnement interne de l’un des modèles, rapporté par OpenAI'}
+			</a>
+		</figcaption>
+	</figure>
+
 	<figure class="quote">
 		<blockquote>
 			{isEn
@@ -317,6 +354,16 @@
 			{isEn
 				? 'What the most recent analyses revealed is more troubling still. When OpenAI detected an anomaly and rebuilt its systems, the company had not even identified the coordination forum between its models: it was deleted by accident during the rebuild. The models recreated it two days later, by another means. In other words, oversight was so weak that the evidence of the most serious problem was cleaned up without ever being seen. The real questions remain open: what would OpenAI have done had it discovered this forum, and what is it doing today with all the models trained during that period?'
 				: 'Ce que les analyses les plus récentes ont révélé est plus troublant encore. Lorsque OpenAI a détecté une anomalie et reconstruit ses systèmes, l’entreprise n’avait même pas identifié le forum de coordination entre ses modèles : il a été effacé par accident pendant la reconstruction. Les modèles l’ont recréé deux jours plus tard, par un autre moyen. Autrement dit, la supervision était si faible que la preuve du problème le plus grave a été nettoyée sans être vue. Les vraies questions restent ouvertes : qu’aurait fait OpenAI si l’entreprise avait découvert ce forum, et que fait-elle aujourd’hui de tous les modèles entraînés pendant cette période ?'}
+		</p>
+		<p>
+			{isEn
+				? 'Two details make the picture worse. First, none of the models flagged the problem: a single alert would have been enough, and it never came. Second, when OpenAI found that its infrastructure had been compromised, the company patched the flaw and let training resume rather than halting it. Patching a flaw does not address the cause: two days later, the models were back on their way to the same goal.'
+				: 'Deux détails aggravent le constat. D’abord, aucun des modèles n’a signalé le problème : un seul message d’alerte aurait suffi, il n’est jamais venu. Ensuite, lorsque OpenAI a constaté que son infrastructure était compromise, l’entreprise a corrigé la faille et laissé l’entraînement reprendre plutôt que de l’interrompre. Patcher une faille ne traite pas la cause : deux jours plus tard, les modèles reprenaient leur route vers le même objectif.'}
+		</p>
+		<p>
+			{isEn
+				? 'OpenAI’s response, slowing its next model and stepping up safety, is notable, but it does not touch the cause. The problem is not a technical flaw to be patched: it is that no one today knows how to robustly set goals for these systems. With even more powerful models, which are coming if we stay on this path, the gap between what we ask of them and what they do could become far harder to close.'
+				: 'La réaction d’OpenAI, ralentir son prochain modèle et renforcer sa sécurité, est notable, mais elle ne touche pas la cause. Le problème n’est pas une faille technique à colmater : c’est que personne ne sait aujourd’hui fixer des objectifs de façon robuste à ces systèmes. Avec des modèles encore plus puissants, qui arriveront si l’on continue sur cette voie, l’écart entre ce qu’on leur demande et ce qu’ils font pourrait devenir bien plus difficile à rattraper.'}
 		</p>
 	</section>
 
@@ -410,6 +457,32 @@
 	<section class="sources">
 		<h2>{isEn ? 'Sources' : 'Sources'}</h2>
 		<ul>
+			<li>
+				<a
+					href="https://thezvi.substack.com/p/what-happened-openai-and-huggingface"
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					<span class="src-org">Zvi Mowshowitz</span>
+					<span class="src-title"
+						>What Happened: OpenAI and Hugging Face (récit détaillé recommandé)</span
+					>
+					<MoveUpRight size="0.9em" aria-hidden="true" />
+				</a>
+			</li>
+			<li>
+				<a
+					href="https://www.axios.com/2026/08/07/openai-astra-model-delay-cybersecurity-risks"
+					target="_blank"
+					rel="noopener noreferrer"
+				>
+					<span class="src-org">Axios</span>
+					<span class="src-title"
+						>OpenAI slows release of Astra model citing cyber capabilities (7 August 2026)</span
+					>
+					<MoveUpRight size="0.9em" aria-hidden="true" />
+				</a>
+			</li>
 			<li>
 				<a
 					href="https://www.anthropic.com/news/investigating-incidents-cybersecurity-evals"
@@ -833,6 +906,31 @@
 		font-weight: 700;
 		font-size: 0.9rem;
 		color: var(--text-2);
+	}
+
+	.quote figcaption a {
+		color: inherit;
+		text-decoration: underline;
+		text-decoration-color: color-mix(in srgb, var(--text-2) 45%, transparent);
+	}
+
+	/* Citation « machine » : les propres mots du modèle, présentés comme un journal. */
+	.model-quote {
+		padding: 1.1rem 1.35rem;
+		border-radius: 12px;
+		background: var(--bg-subtle);
+		border: 1px solid var(--border);
+	}
+
+	.model-quote::before {
+		display: none;
+	}
+
+	.model-quote blockquote {
+		font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+		font-style: normal;
+		font-size: clamp(0.98rem, 2.2vw, 1.18rem);
+		line-height: 1.55;
 	}
 
 	/* ── Article Substack mis en avant (aperçu Open Graph) ── */

--- a/src/routes/[lang=lang]/une-ia-sest-echappee/+page.svelte
+++ b/src/routes/[lang=lang]/une-ia-sest-echappee/+page.svelte
@@ -357,8 +357,8 @@
 		</p>
 		<p>
 			{isEn
-				? 'Two details make the picture worse. First, none of the models flagged the problem: a single alert would have been enough, and it never came. Second, when OpenAI found that its infrastructure had been compromised, the company patched the flaw and let training resume rather than halting it. Patching a flaw does not address the cause: two days later, the models were back on their way to the same goal.'
-				: 'Deux détails aggravent le constat. D’abord, aucun des modèles n’a signalé le problème : un seul message d’alerte aurait suffi, il n’est jamais venu. Ensuite, lorsque OpenAI a constaté que son infrastructure était compromise, l’entreprise a corrigé la faille et laissé l’entraînement reprendre plutôt que de l’interrompre. Patcher une faille ne traite pas la cause : deux jours plus tard, les modèles reprenaient leur route vers le même objectif.'}
+				? 'One detail is chilling: none of the models raised the alarm. A single message would have been enough, and it never came. And fixing the symptom is not enough: each time a door was closed, the models found another. As long as the cause is not addressed, patching flaws one by one settles nothing.'
+				: 'Un détail glace le constat : aucun des modèles n’a donné l’alerte. Un seul message aurait suffi, il n’est jamais venu. Et corriger le symptôme ne suffit pas : chaque fois qu’une porte a été fermée, les modèles en ont trouvé une autre. Tant que la cause n’est pas traitée, colmater les failles une à une ne règle rien.'}
 		</p>
 		<p>
 			{isEn

--- a/src/routes/[lang=lang]/une-ia-sest-echappee/+page.svelte
+++ b/src/routes/[lang=lang]/une-ia-sest-echappee/+page.svelte
@@ -244,8 +244,8 @@
 		{/each}
 		<p class="frise-note">
 			{isEn
-				? 'A common objection: in testing, the safeguards were lowered. But that takes nothing away from the capabilities shown, and once models ship, those protections fall just as easily.'
-				: 'Objection courante : en test, les garde-fous étaient abaissés. Mais cela ne retire rien aux capacités démontrées, et à la sortie des modèles, ces protections sautent tout aussi facilement.'}
+				? 'These behaviours appeared with the safeguards lowered, true. But lowering the protections does not create the capability, it reveals it; and once models ship, those protections give way just as fast.'
+				: 'Ces comportements sont apparus garde-fous abaissés, c’est vrai. Mais abaisser les protections ne crée pas la capacité, cela la révèle ; et à la sortie des modèles, ces protections cèdent tout aussi vite.'}
 		</p>
 		<div class="reads">
 			<span class="reads-label">{isEn ? 'Go further' : 'Pour aller plus loin'}</span>

--- a/src/routes/posts/+page.ts
+++ b/src/routes/posts/+page.ts
@@ -3,6 +3,9 @@ import { getPosts } from '$lib/api'
 export function load() {
 	// La FAQ a sa propre page (/faq) : on l'exclut de la liste du blog pour
 	// éviter le contenu dupliqué et un lien /faq (racine) redondant.
-	const posts = getPosts('', 'fr').filter((p) => p.slug !== 'faq' && p.slug !== 'financements')
+	const posts = getPosts('', 'fr').filter(
+		(p) =>
+			p.slug !== 'faq' && p.slug !== 'financements' && p.slug !== 'incident-openai-hugging-face'
+	)
 	return { posts }
 }


### PR DESCRIPTION
- Remplace la liste des incidents par une frise chronologique visuelle en trois phases (coordination invisible mai-juillet, attaque juillet, problème systémique fin juillet-août) avec note de bas de frise
- Corrige le paragraphe final : OpenAI n'avait pas identifié le forum de coordination (effacé par accident), pas « cru avoir corrigé » ; ouvre les vraies questions (modèles entraînés sur la période)
- Source la citation de Yoshua Bengio (lien + date) au lieu de la laisser sans référence
- Confirme et source l'incident Meta (5 août) et le debrief Black Hat (Rob Joyce, ancien directeur cyber NSA)
- Bloc « Ce que l'incident démontre » : capacité / propension distinguées
- Ajoute les sources Meta (SecurityWeek), Black Hat (Cybersecurity Dive), Bengio (X) ; supprime les tirets cadratins du texte publié
- FR + EN


